### PR TITLE
feat: improve database daily update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Data folders
+data/
+local_data/

--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,7 @@ deep-translator = "==1.5.4"
 psycopg2 = "==2.9.3"
 sqlmodel = "0.0.6"
 python-telegram-bot = "==20.0a0"
-
+python-dotenv = "*"
 
 [dev-packages]
 

--- a/db_populator.py
+++ b/db_populator.py
@@ -21,7 +21,6 @@ MANAGED_TEAMS = get_managed_teams_config()
 logger = get_logger(__name__)
 
 
-
 def insert_league(fixture_league: Championship) -> DBLeague:
     league_statement = select(DBLeague).where(DBLeague.id == fixture_league.league_id)
     retrieved_league = NOTIFIER_DB_MANAGER.select_records(league_statement)
@@ -66,8 +65,12 @@ def save_fixtures(team_fixtures: List[dict]) -> None:
     converted_fixtures = []
     fix_nr = 1
     for fixture in team_fixtures:
-        fixture_match = f'{fixture["teams"]["home"]["name"]} vs. {fixture["teams"]["away"]["name"]}'
-        logger.info(f"Converting & populating fixture {fix_nr}/{len(team_fixtures)} - {fixture_match}")
+        fixture_match = (
+            f'{fixture["teams"]["home"]["name"]} vs. {fixture["teams"]["away"]["name"]}'
+        )
+        logger.info(
+            f"Converting & populating fixture {fix_nr}/{len(team_fixtures)} - {fixture_match}"
+        )
         converted_fixtures.append(convert_fixture_response_to_db(fixture))
         fix_nr += 1
 
@@ -132,11 +135,11 @@ def populate_initial_data() -> None:
 
 def update_fixtures() -> None:
     """
-        This function updates only fixtures corresponding to the
-        last & next match for each managed team, given that this is
-        at the moment the only that the user can query, doesn't make sense to
-        query all the fixtures for all teams. This way we can save dozens of
-        RAPID API hits per day, giving space to multiple other functionalities.
+    This function updates only fixtures corresponding to the
+    last & next match for each managed team, given that this is
+    at the moment the only that the user can query, doesn't make sense to
+    query all the fixtures for all teams. This way we can save dozens of
+    RAPID API hits per day, giving space to multiple other functionalities.
     """
     fixtures_client = FixturesClient()
     fixtures_to_update = get_all_fixtures_to_update()
@@ -147,9 +150,11 @@ def update_fixtures() -> None:
         save_fixtures(team_fixtures.as_dict["response"])
 
 
-def get_fixture_update_lots(fixtures_to_update: List[int], lot_size=20) -> List[List[int]]:
+def get_fixture_update_lots(
+    fixtures_to_update: List[int], lot_size: int = 20
+) -> List[List[int]]:
     for i in range(0, len(fixtures_to_update), lot_size):
-        yield fixtures_to_update[i:i + lot_size]
+        yield fixtures_to_update[i : i + lot_size]
 
 
 def get_all_fixtures_to_update() -> List[DBFixture]:

--- a/db_populator.py
+++ b/db_populator.py
@@ -66,7 +66,8 @@ def save_fixtures(team_fixtures: List[dict]) -> None:
     converted_fixtures = []
     fix_nr = 1
     for fixture in team_fixtures:
-        logger.info(f"Converting & populating fixture {fix_nr}/{len(team_fixtures)}")
+        fixture_match = f'{fixture["teams"]["home"]["name"]} vs. {fixture["teams"]["away"]["name"]}'
+        logger.info(f"Converting & populating fixture {fix_nr}/{len(team_fixtures)} - {fixture_match}")
         converted_fixtures.append(convert_fixture_response_to_db(fixture))
         fix_nr += 1
 
@@ -113,21 +114,42 @@ def save_fixtures(team_fixtures: List[dict]) -> None:
     NOTIFIER_DB_MANAGER.insert_records(db_fixtures)
 
 
-def populate_data(is_initial: bool = False) -> None:
+def populate_initial_data() -> None:
     fixtures_client = FixturesClient()
     current_year = date.today().year
     last_year = current_year - 1
 
     for team in MANAGED_TEAMS:
         logger.info(f"Saving fixtures for team {team.name}")
-        if is_initial:
-            team_fixtures = fixtures_client.get_fixtures_by(str(last_year), team.id)
-            if "response" in team_fixtures.as_dict:
-                save_fixtures(team_fixtures.as_dict["response"])
+        team_fixtures = fixtures_client.get_fixtures_by(str(last_year), team.id)
+        if "response" in team_fixtures.as_dict:
+            save_fixtures(team_fixtures.as_dict["response"])
 
         team_fixtures = fixtures_client.get_fixtures_by(str(current_year), team.id)
         if "response" in team_fixtures.as_dict:
             save_fixtures(team_fixtures.as_dict["response"])
+
+
+def update_fixtures() -> None:
+    """
+        This function updates only fixtures corresponding to the
+        last & next match for each managed team, given that this is
+        at the moment the only that the user can query, doesn't make sense to
+        query all the fixtures for all teams. This way we can save dozens of
+        RAPID API hits per day, giving space to multiple other functionalities.
+    """
+    fixtures_client = FixturesClient()
+    fixtures_to_update = get_all_fixtures_to_update()
+    lots_to_update = get_fixture_update_lots(fixtures_to_update)
+
+    for lot in lots_to_update:
+        team_fixtures = fixtures_client.get_fixtures_by(ids=lot)
+        save_fixtures(team_fixtures.as_dict["response"])
+
+
+def get_fixture_update_lots(fixtures_to_update: List[int], lot_size=20) -> List[List[int]]:
+    for i in range(0, len(fixtures_to_update), lot_size):
+        yield fixtures_to_update[i:i + lot_size]
 
 
 def get_all_fixtures_to_update() -> List[DBFixture]:
@@ -137,12 +159,17 @@ def get_all_fixtures_to_update() -> List[DBFixture]:
         all_fixtures_to_update.append(team_fixtures_manager.get_next_team_fixture())
         all_fixtures_to_update.append(team_fixtures_manager.get_last_team_fixture())
 
-    return [fixture for fixture in all_fixtures_to_update if fixture]
+    return [fixture.id for fixture in all_fixtures_to_update if fixture]
 
 
 if __name__ == "__main__":
     logger.info("Populating data...")
     fixtures = NOTIFIER_DB_MANAGER.select_records(select(DBFixture))
     is_initial = True if not len(fixtures) else False
+
     logger.info(f"IS_INITIAL -> {is_initial}")
-    populate_data(is_initial)
+
+    if is_initial:
+        populate_initial_data()
+    else:
+        update_fixtures()

--- a/src/api/fixtures_client.py
+++ b/src/api/fixtures_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from src.api.base_client import BaseClient
 from src.request import APIRequest
@@ -9,9 +9,19 @@ class FixturesClient(BaseClient):
         super().__init__()
         self.request = APIRequest()
 
-    def get_fixtures_by(self, season: int, team_id: int) -> Dict[str, Any]:
+    def get_fixtures_by(self, season: int = None, team_id: int = None, ids: List[int] = []) -> Dict[str, Any]:
         endpoint = "/v3/fixtures"
-        params = {"season": season, "team": team_id}
+        params = {}
+
+        if season:
+            params["season"] = season
+
+        if team_id:
+            params["team"] = team_id
+
+        if len(ids):
+            params["ids"] = "-".join([str(fix_id) for fix_id in ids])
+
         url = f"{self.base_url}{endpoint}"
 
         return self.request.get(url, params, self.headers)

--- a/src/api/fixtures_client.py
+++ b/src/api/fixtures_client.py
@@ -9,7 +9,9 @@ class FixturesClient(BaseClient):
         super().__init__()
         self.request = APIRequest()
 
-    def get_fixtures_by(self, season: int = None, team_id: int = None, ids: List[int] = []) -> Dict[str, Any]:
+    def get_fixtures_by(
+        self, season: int = None, team_id: int = None, ids: List[int] = []
+    ) -> Dict[str, Any]:
         endpoint = "/v3/fixtures"
         params = {}
 

--- a/src/team_fixtures_manager.py
+++ b/src/team_fixtures_manager.py
@@ -76,7 +76,6 @@ class TeamFixturesManager:
 
         return next_team_fixture
 
-
     def notify_next_fixture_db(self) -> None:
         next_team_fixture = self.get_next_team_fixture()
 

--- a/src/team_fixtures_manager.py
+++ b/src/team_fixtures_manager.py
@@ -57,14 +57,17 @@ class TeamFixturesManager:
             else ("Fixture para el equipo no encontrado", "")
         )
 
-    def get_next_team_fixture(self) -> Optional[Fixture]:
+    def get_team_db_fixtures(self) -> Optional[List[DBFixture]]:
         fixtures_statement = select(DBFixture).where(
             or_(
                 DBFixture.home_team == self._team_id,
                 DBFixture.away_team == self._team_id,
             )
         )
-        team_fixtures = self._notifier_db_manager.select_records(fixtures_statement)
+        return self._notifier_db_manager.select_records(fixtures_statement)
+
+    def get_next_team_fixture(self) -> Optional[Fixture]:
+        team_fixtures = self.get_team_db_fixtures()
 
         next_team_fixture = None
 
@@ -72,6 +75,7 @@ class TeamFixturesManager:
             next_team_fixture = get_next_fixture_db(team_fixtures)
 
         return next_team_fixture
+
 
     def notify_next_fixture_db(self) -> None:
         next_team_fixture = self.get_next_team_fixture()
@@ -132,13 +136,7 @@ class TeamFixturesManager:
 
     def get_last_team_fixture(self) -> Optional[Fixture]:
         logger.info(f"Getting last fixture for team {self._team_id}")
-        fixtures_statement = select(DBFixture).where(
-            or_(
-                DBFixture.home_team == self._team_id,
-                DBFixture.away_team == self._team_id,
-            )
-        )
-        team_fixtures = self._notifier_db_manager.select_records(fixtures_statement)
+        team_fixtures = self.get_team_db_fixtures()
 
         last_team_fixture = None
 

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -199,7 +199,7 @@ def convert_db_fixture(fixture: DBFixture) -> Fixture:
             away_team.picture,
             get_team_aliases(str(away_team.id)),
         ),
-        MatchScore(fixture.home_score, fixture.away_score)
+        MatchScore(fixture.home_score, fixture.away_score),
     )
 
 

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -199,8 +199,7 @@ def convert_db_fixture(fixture: DBFixture) -> Fixture:
             away_team.picture,
             get_team_aliases(str(away_team.id)),
         ),
-        MatchScore(fixture.home_score, fixture.away_score),
-        # get_line_up(fixture_response["fixture"]["id"], team_id),
+        MatchScore(fixture.home_score, fixture.away_score)
     )
 
 

--- a/tests/test_db_populator.py
+++ b/tests/test_db_populator.py
@@ -1,0 +1,54 @@
+from db_populator import get_fixture_update_lots
+from pathlib import Path
+from dotenv import load_dotenv
+
+current_path = Path(__file__).parent.absolute()
+env_file = current_path / ".." / "football_notifier.env"
+load_dotenv(env_file)
+
+
+def test_get_fixture_update_lots():
+    # given
+    all_fixtures_ids = [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+    ]
+
+    # when
+    fixture_lots = get_fixture_update_lots(all_fixtures_ids)
+
+    # then
+    fixture_lots_list = list(fixture_lots)
+    assert fixture_lots_list == [
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    ]


### PR DESCRIPTION
Improving daily updates for fixtures, leaving the full query just for the **initial**  population and from then on, as we already have all the fixtures for the corresponding teams, we can make usage of the Rapid API endpoint possibility of querying multiple fixture `ids` in a single call and therefore save multiple API hits per day (allowing space to many other functionalities).