### PR TITLE
23 head to head records for teams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY ./Pipfile.lock ./Pipfile.lock
 COPY team_fixture_notifier.py .
 COPY db_initializer.py .
 COPY db_populator.py .
+COPY head_to_head_updater.py .
 COPY notifier_bot.py .
 COPY football_notifier.env .
 

--- a/db_populator.py
+++ b/db_populator.py
@@ -100,4 +100,3 @@ if __name__ == "__main__":
     logger.info(f"IS_INITIAL -> {is_initial}")
 
     populate_data(is_initial)
-    insert_head_to_heads()

--- a/db_populator.py
+++ b/db_populator.py
@@ -1,120 +1,36 @@
 from datetime import date
 from typing import List
 
-from sqlmodel import select
-
 from config.config_utils import get_managed_teams_config
 from src.api.fixtures_client import FixturesClient
-from src.db.db_manager import NotifierDBManager
-from src.db.notif_sql_models import Fixture as DBFixture
-from src.db.notif_sql_models import League as DBLeague
-from src.db.notif_sql_models import Team as DBTeam
-from src.entities import Championship, Team
+from src.db.fixtures_db_manager import FixturesDBManager
+from src.entities import Fixture, FixtureForDB
 from src.notifier_logger import get_logger
-from src.team_fixtures_manager import TeamFixturesManager
-from src.utils.fixtures_utils import convert_fixture_response_to_db
+from src.utils.fixtures_utils import convert_fixture_response_to_db, \
+    insert_head_to_heads
 
-NOTIFIER_DB_MANAGER = NotifierDBManager()
-
+FIXTURES_DB_MANAGER = FixturesDBManager()
 MANAGED_TEAMS = get_managed_teams_config()
 
 logger = get_logger(__name__)
 
 
-def insert_league(fixture_league: Championship) -> DBLeague:
-    league_statement = select(DBLeague).where(DBLeague.id == fixture_league.league_id)
-    retrieved_league = NOTIFIER_DB_MANAGER.select_records(league_statement)
-
-    if not len(retrieved_league):
-        logger.info(
-            f"Inserting League {fixture_league.name} - it does not exist in the database"
-        )
-        league = DBLeague(
-            id=fixture_league.league_id,
-            name=fixture_league.name,
-            logo=fixture_league.logo,
-            country=fixture_league.country,
-        )
-        NOTIFIER_DB_MANAGER.insert_record(league)
-        retrieved_league = NOTIFIER_DB_MANAGER.select_records(league_statement)
-
-    return retrieved_league
-
-
-def insert_team(fixture_team: Team) -> DBTeam:
-    team_statement = select(DBTeam).where(DBTeam.id == fixture_team.id)
-    retrieved_team = NOTIFIER_DB_MANAGER.select_records(team_statement)
-
-    if not len(retrieved_team):
-        logger.info(
-            f"Inserting Team {fixture_team.name} - it does not exist in the database"
-        )
-        team = DBTeam(
-            id=fixture_team.id,
-            name=fixture_team.name,
-            picture=fixture_team.picture,
-            aliases=fixture_team.aliases,
-        )
-        NOTIFIER_DB_MANAGER.insert_record(team)
-        retrieved_team = NOTIFIER_DB_MANAGER.select_records(team_statement)
-
-    return retrieved_team
-
-
-def save_fixtures(team_fixtures: List[dict]) -> None:
+def get_converted_fixtures_to_db(fixtures: List[Fixture]) -> List[FixtureForDB]:
     converted_fixtures = []
     fix_nr = 1
-    for fixture in team_fixtures:
+    for fixture in fixtures:
         fixture_match = (
-            f'{fixture["teams"]["home"]["name"]} vs. {fixture["teams"]["away"]["name"]}'
+            f'{fixture["teams"]["home"]["name"]} vs. '
+            f'{fixture["teams"]["away"]["name"]}'
         )
         logger.info(
-            f"Converting & populating fixture {fix_nr}/{len(team_fixtures)} - {fixture_match}"
+            f"Converting & populating fixture {fix_nr}/"
+            f"{len(fixtures)} - {fixture_match}"
         )
         converted_fixtures.append(convert_fixture_response_to_db(fixture))
         fix_nr += 1
 
-    db_fixtures = []
-
-    for conv_fix in converted_fixtures:
-        retrieved_league = insert_league(conv_fix.championship)
-        retrieved_home_team = insert_team(conv_fix.home_team)
-        retrieved_away_team = insert_team(conv_fix.away_team)
-
-        fixture_statement = select(DBFixture).where(DBFixture.id == conv_fix.id)
-        retrieved_fixture = NOTIFIER_DB_MANAGER.select_records(fixture_statement)
-
-        if not len(retrieved_fixture):
-            logger.info(
-                f"Inserting Fixture {conv_fix.home_team.name} vs {conv_fix.away_team.name} - it does not exist in the database"
-            )
-            db_fixture = DBFixture(
-                id=conv_fix.id,
-                utc_date=conv_fix.utc_date,
-                league=retrieved_league.pop().id,
-                round=conv_fix.round,
-                home_team=retrieved_home_team.pop().id,
-                away_team=retrieved_away_team.pop().id,
-                home_score=conv_fix.match_score.home_score,
-                away_score=conv_fix.match_score.away_score,
-            )
-        else:
-            logger.info(
-                f"Updating Fixture {conv_fix.home_team.name} vs {conv_fix.away_team.name}"
-            )
-            db_fixture = retrieved_fixture.pop()
-            db_fixture.id = conv_fix.id
-            db_fixture.utc_date = conv_fix.utc_date
-            db_fixture.league = retrieved_league.pop().id
-            db_fixture.round = conv_fix.round
-            db_fixture.home_team = retrieved_home_team.pop().id
-            db_fixture.away_team = retrieved_away_team.pop().id
-            db_fixture.home_score = conv_fix.match_score.home_score
-            db_fixture.away_score = conv_fix.match_score.away_score
-
-        db_fixtures.append(db_fixture)
-
-    NOTIFIER_DB_MANAGER.insert_records(db_fixtures)
+    return converted_fixtures
 
 
 def populate_data(is_initial=False) -> None:
@@ -128,52 +44,60 @@ def populate_data(is_initial=False) -> None:
         if is_initial:
             team_fixtures = fixtures_client.get_fixtures_by(str(last_year), team.id)
             if "response" in team_fixtures.as_dict:
-                save_fixtures(team_fixtures.as_dict["response"])
+                FIXTURES_DB_MANAGER.save_fixtures(
+                    get_converted_fixtures_to_db(team_fixtures.as_dict["response"])
+                )
 
         team_fixtures = fixtures_client.get_fixtures_by(str(current_year), team.id)
         if "response" in team_fixtures.as_dict:
-            save_fixtures(team_fixtures.as_dict["response"])
+            FIXTURES_DB_MANAGER.save_fixtures(
+                get_converted_fixtures_to_db(team_fixtures.as_dict["response"])
+            )
 
 
-def update_fixtures() -> None:
-    """
-    This function updates only fixtures corresponding to the
-    last & next match for each managed team, given that this is
-    at the moment the only that the user can query, doesn't make sense to
-    query all the fixtures for all teams. This way we can save dozens of
-    RAPID API hits per day, giving space to multiple other functionalities.
-    """
-    fixtures_client = FixturesClient()
-    fixtures_to_update = get_all_fixtures_to_update()
-    lots_to_update = get_fixture_update_lots(fixtures_to_update)
-
-    for lot in lots_to_update:
-        team_fixtures = fixtures_client.get_fixtures_by(ids=lot)
-        save_fixtures(team_fixtures.as_dict["response"])
-
-
-def get_fixture_update_lots(
-    fixtures_to_update: List[int], lot_size: int = 20
-) -> List[List[int]]:
-    for i in range(0, len(fixtures_to_update), lot_size):
-        yield fixtures_to_update[i : i + lot_size]
-
-
-def get_all_fixtures_to_update() -> List[DBFixture]:
-    all_fixtures_to_update = []
-    for team in MANAGED_TEAMS:
-        team_fixtures_manager = TeamFixturesManager(date.today().year, team.id)
-        all_fixtures_to_update.append(team_fixtures_manager.get_next_team_fixture())
-        all_fixtures_to_update.append(team_fixtures_manager.get_last_team_fixture())
-
-    return [fixture.id for fixture in all_fixtures_to_update if fixture]
+# def update_fixtures() -> None:
+#     """
+#     This function updates only fixtures corresponding to the
+#     last & next match for each managed team, given that this is
+#     at the moment the only that the user can query, doesn't make sense to
+#     query all the fixtures for all teams. This way we can save dozens of
+#     RAPID API hits per day, giving space to multiple other functionalities.
+#     """
+#     fixtures_client = FixturesClient()
+#     fixtures_to_update = get_all_fixtures_to_update()
+#     lots_to_update = get_fixture_update_lots(fixtures_to_update)
+#
+#     for lot in lots_to_update:
+#         team_fixtures = fixtures_client.get_fixtures_by(ids=lot)
+#         save_fixtures(team_fixtures.as_dict["response"])
+#
+#
+# def get_fixture_update_lots(
+#         fixtures_to_update: List[int], lot_size: int = 20
+# ) -> List[List[int]]:
+#     for i in range(0, len(fixtures_to_update), lot_size):
+#         yield fixtures_to_update[i: i + lot_size]
+#
+#
+# def get_all_fixtures_to_update() -> List[DBFixture]:
+#     all_fixtures_to_update = []
+#     for team in MANAGED_TEAMS:
+#         team_fixtures_manager = TeamFixturesManager(date.today().year,
+#         team.id)
+#         all_fixtures_to_update.append(
+#             team_fixtures_manager.get_next_team_fixture())
+#         all_fixtures_to_update.append(
+#             team_fixtures_manager.get_last_team_fixture())
+#
+#     return [fixture.id for fixture in all_fixtures_to_update if fixture]
 
 
 if __name__ == "__main__":
     logger.info("Populating data...")
-    fixtures = NOTIFIER_DB_MANAGER.select_records(select(DBFixture))
+    fixtures = FIXTURES_DB_MANAGER.get_all_fixtures()
     is_initial = True if not len(fixtures) else False
 
     logger.info(f"IS_INITIAL -> {is_initial}")
 
     populate_data(is_initial)
+    insert_head_to_heads()

--- a/dev_scripts/update_head_to_heads.sh
+++ b/dev_scripts/update_head_to_heads.sh
@@ -1,0 +1,5 @@
+cd /usr/football_api
+/usr/local/bin/python -m pipenv shell
+
+/usr/local/bin/python -m pipenv run python /usr/football_api/head_to_head_updater.py
+

--- a/football_notif_crontab
+++ b/football_notif_crontab
@@ -1,5 +1,5 @@
 30 12 * * * /usr/football_api/dev_scripts/run_next_match_notifier.sh >> /var/log/cron_log.log 2>&1
 30 8 * * * /usr/football_api/dev_scripts/run_played_match_notifier.sh >> /var/log/cron_log.log 2>&1
 30 5 * * * /usr/football_api/dev_scripts/populate_database.sh >> /var/log/cron_log.log 2>&1
-30 5 */5 * * /usr/football_api/dev_scripts/populate_database.sh >> /var/log/cron_log.log 2>&1
+30 5 */5 * * /usr/football_api/dev_scripts/update_head_to_heads.sh >> /var/log/cron_log.log 2>&1
 # Extra valid line

--- a/football_notif_crontab
+++ b/football_notif_crontab
@@ -1,4 +1,5 @@
 30 12 * * * /usr/football_api/dev_scripts/run_next_match_notifier.sh >> /var/log/cron_log.log 2>&1
 30 8 * * * /usr/football_api/dev_scripts/run_played_match_notifier.sh >> /var/log/cron_log.log 2>&1
 30 5 * * * /usr/football_api/dev_scripts/populate_database.sh >> /var/log/cron_log.log 2>&1
+30 5 */5 * * /usr/football_api/dev_scripts/populate_database.sh >> /var/log/cron_log.log 2>&1
 # Extra valid line

--- a/head_to_head_updater.py
+++ b/head_to_head_updater.py
@@ -1,0 +1,9 @@
+from src.notifier_logger import get_logger
+from src.utils.fixtures_utils import insert_head_to_heads
+
+logger = get_logger(__name__)
+
+
+if __name__ == "__main__":
+    logger.info("Inserting head to head records...")
+    insert_head_to_heads()

--- a/src/api/fixtures_client.py
+++ b/src/api/fixtures_client.py
@@ -27,6 +27,21 @@ class FixturesClient(BaseClient):
         if len(ids):
             params["ids"] = "-".join([str(fix_id) for fix_id in ids])
 
+        if h2h:
+            params["h2h"] = h2h
+
+        url = f"{self.base_url}{endpoint}"
+
+        response = self.request.get(url, params, self.headers)
+
+        logger.info(f"get_fixtures_by response - {response.status_code}")
+
+        return response
+
+    def get_head_to_head(self, team_1: str, team_2: str) -> Dict[str, Any]:
+        endpoint = "/v3/fixtures/headtohead"
+        params = {"h2h": f"{team_1}-{team_2}"}
+
         url = f"{self.base_url}{endpoint}"
 
         response = self.request.get(url, params, self.headers)

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -59,6 +59,7 @@ class FixturesDBManager:
                 or_(DBFixture.home_team == team_1, DBFixture.away_team == team_1),
             )
             .where(or_(DBFixture.home_team == team_2, DBFixture.away_team == team_2))
+            .order_by(DBFixture.utc_date)
         )
 
         fixtures = self._notifier_db_manager.select_records(statement)

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -23,6 +23,21 @@ class FixturesDBManager:
     def get_all_fixtures(self) -> List[Optional[DBFixture]]:
         return self._notifier_db_manager.select_records(select(DBFixture))
 
+
+    def get_games_in_following_n_days(self, days: int) -> List[Optional[DBFixture]]:
+        fixtures = []
+
+        for day in range(1, days + 1):
+            today = datetime.today()
+            following_day = today + timedelta(days=days)
+            bsas_date = get_time_in_time_zone(following_day, TimeZones.BSAS)
+            tomorrow_str = bsas_date.strftime("%Y-%m-%d")
+
+            statement = select(DBFixture).where(DBFixture.utc_date.contains(tomorrow_str))
+            fixtures.append(self._notifier_db_manager.select_records(statement))
+
+        return fixtures
+
     def get_tomorrow_games(self) -> List[Optional[DBFixture]]:
         today = datetime.today()
         tomorrow = today + timedelta(days=1)

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -29,7 +29,7 @@ class FixturesDBManager:
 
         for day in range(1, days + 1):
             today = datetime.today()
-            following_day = today + timedelta(days=days)
+            following_day = today + timedelta(days=day)
             bsas_date = get_time_in_time_zone(following_day, TimeZones.BSAS)
             tomorrow_str = bsas_date.strftime("%Y-%m-%d")
 

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -34,7 +34,7 @@ class FixturesDBManager:
             tomorrow_str = bsas_date.strftime("%Y-%m-%d")
 
             statement = select(DBFixture).where(DBFixture.utc_date.contains(tomorrow_str))
-            fixtures.append(self._notifier_db_manager.select_records(statement))
+            fixtures = fixtures + self._notifier_db_manager.select_records(statement)
 
         return fixtures
 

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from sqlmodel import select, or_
+
+from src.db.db_manager import NotifierDBManager
+from src.db.notif_sql_models import (
+    Fixture as DBFixture,
+    Team as DBTeam,
+    League as DBLeague,
+)
+from src.entities import Championship, Team, FixtureForDB
+from src.notifier_logger import get_logger
+from src.utils.date_utils import get_time_in_time_zone, TimeZones
+
+logger = get_logger(__name__)
+
+
+class FixturesDBManager:
+    def __init__(self):
+        self._notifier_db_manager = NotifierDBManager()
+
+    def get_all_fixtures(self) -> List[Optional[DBFixture]]:
+        return self._notifier_db_manager.select_records(select(DBFixture))
+
+    def get_tomorrow_games(self) -> List[Optional[DBFixture]]:
+        today = datetime.today()
+        tomorrow = today + timedelta(days=1)
+        bsas_date = get_time_in_time_zone(tomorrow, TimeZones.BSAS)
+        tomorrow_str = bsas_date.strftime("%Y-%m-%d")
+
+        statement = select(DBFixture).where(DBFixture.utc_date.contains(tomorrow_str))
+
+        return self._notifier_db_manager.select_records(statement)
+
+    def get_today_games(self) -> List[Optional[DBFixture]]:
+        today = datetime.today()
+        bsas_date = get_time_in_time_zone(today, TimeZones.BSAS)
+        today_str = bsas_date.strftime("%Y-%m-%d")
+
+        statement = select(DBFixture).where(DBFixture.utc_date.contains(today_str))
+
+        return self._notifier_db_manager.select_records(statement)
+
+    def get_yesterday_games(self) -> List[Optional[DBFixture]]:
+        today = datetime.today()
+        yesterday = today - timedelta(days=1)
+        bsas_date = get_time_in_time_zone(yesterday, TimeZones.BSAS)
+        yesterday_str = bsas_date.strftime("%Y-%m-%d")
+
+        statement = select(DBFixture).where(DBFixture.utc_date.contains(yesterday_str))
+
+        return self._notifier_db_manager.select_records(statement)
+
+    def get_head_to_head_fixtures(self, team_1: str, team_2: str):
+        statement = (
+            select(DBFixture)
+            .where(
+                or_(DBFixture.home_team == team_1, DBFixture.away_team == team_1),
+            )
+            .where(or_(DBFixture.home_team == team_2, DBFixture.away_team == team_2))
+        )
+
+        fixtures = self._notifier_db_manager.select_records(statement)
+
+        return [fixture for fixture in fixtures if fixture.home_score is not None]
+
+    def insert_league(self, fixture_league: Championship) -> DBLeague:
+        league_statement = select(DBLeague).where(
+            DBLeague.id == fixture_league.league_id
+        )
+        retrieved_league = self._notifier_db_manager.select_records(league_statement)
+
+        if not len(retrieved_league):
+            logger.info(
+                f"Inserting League {fixture_league.name} - it does not exist "
+                f"in the database"
+            )
+            league = DBLeague(
+                id=fixture_league.league_id,
+                name=fixture_league.name,
+                logo=fixture_league.logo,
+                country=fixture_league.country,
+            )
+            self._notifier_db_manager.insert_record(league)
+            retrieved_league = self._notifier_db_manager.select_records(
+                league_statement
+            )
+
+        return retrieved_league
+
+    def insert_team(self, fixture_team: Team) -> DBTeam:
+        team_statement = select(DBTeam).where(DBTeam.id == fixture_team.id)
+        retrieved_team = self._notifier_db_manager.select_records(team_statement)
+
+        if not len(retrieved_team):
+            logger.info(
+                f"Inserting Team {fixture_team.name} - it does not exist in "
+                f"the database"
+            )
+            team = DBTeam(
+                id=fixture_team.id,
+                name=fixture_team.name,
+                picture=fixture_team.picture,
+                aliases=fixture_team.aliases,
+            )
+            self._notifier_db_manager.insert_record(team)
+            retrieved_team = self._notifier_db_manager.select_records(team_statement)
+
+        return retrieved_team
+
+    def save_fixtures(self, team_fixtures: List[FixtureForDB]) -> None:
+        db_fixtures = []
+
+        for conv_fix in team_fixtures:
+            retrieved_league = self.insert_league(conv_fix.championship)
+            retrieved_home_team = self.insert_team(conv_fix.home_team)
+            retrieved_away_team = self.insert_team(conv_fix.away_team)
+
+            fixture_statement = select(DBFixture).where(DBFixture.id == conv_fix.id)
+            retrieved_fixture = self._notifier_db_manager.select_records(
+                fixture_statement
+            )
+
+            if not len(retrieved_fixture):
+                logger.info(
+                    f"Inserting Fixture {conv_fix.home_team.name} vs "
+                    f"{conv_fix.away_team.name} - it does not exist in the "
+                    f"database"
+                )
+                db_fixture = DBFixture(
+                    id=conv_fix.id,
+                    utc_date=conv_fix.utc_date,
+                    league=retrieved_league.pop().id,
+                    round=conv_fix.round,
+                    home_team=retrieved_home_team.pop().id,
+                    away_team=retrieved_away_team.pop().id,
+                    home_score=conv_fix.match_score.home_score,
+                    away_score=conv_fix.match_score.away_score,
+                )
+            else:
+                logger.info(
+                    f"Updating Fixture {conv_fix.home_team.name} vs "
+                    f"{conv_fix.away_team.name}"
+                )
+                db_fixture = retrieved_fixture.pop()
+                db_fixture.id = conv_fix.id
+                db_fixture.utc_date = conv_fix.utc_date
+                db_fixture.league = retrieved_league.pop().id
+                db_fixture.round = conv_fix.round
+                db_fixture.home_team = retrieved_home_team.pop().id
+                db_fixture.away_team = retrieved_away_team.pop().id
+                db_fixture.home_score = conv_fix.match_score.home_score
+                db_fixture.away_score = conv_fix.match_score.away_score
+
+            db_fixtures.append(db_fixture)
+
+        self._notifier_db_manager.insert_records(db_fixtures)

--- a/src/emojis.py
+++ b/src/emojis.py
@@ -47,3 +47,5 @@ class Emojis(Enum):
     PIRATE_FLAG = emoji.emojize(":pirate_flag:", use_aliases=True)
     WHITE_CIRCLE = emoji.emojize(":white_circle:", use_aliases=True)
     RED_CIRCLE = emoji.emojize(":red_circle:", use_aliases=True)
+    RIGHT_FACING_FIST = emoji.emojize(":right-facing_fist:", use_aliases=True)
+    LEFT_FACING_FIST = emoji.emojize(":left-facing_fist:", use_aliases=True)

--- a/src/entities.py
+++ b/src/entities.py
@@ -179,8 +179,8 @@ class Fixture:
             for h2h_fixture in reversed(self.head_to_head[-5:]):
                 date_to_show = h2h_fixture.bsas_date.strftime("%Y-%m-%d")
                 head_to_head_list += (
-                    f"{Emojis.SPIRAL_CALENDAR.value} <strong>{date_to_show}</strong>\n"
-                    f"{Emojis.SOCCER_BALL.value} <strong>{h2h_fixture.home_team.name} [{h2h_fixture.match_score.home_score}] vs [{h2h_fixture.match_score.away_score}] {h2h_fixture.away_team.name}</strong>\n\n"
+                    f"{Emojis.SPIRAL_CALENDAR.value} {date_to_show}\n"
+                    f"{Emojis.SOCCER_BALL.value} {h2h_fixture.home_team.name} [{h2h_fixture.match_score.home_score}] vs [{h2h_fixture.match_score.away_score}] {h2h_fixture.away_team.name}\n\n"
                 )
 
             h2h_text = (
@@ -232,7 +232,7 @@ class Fixture:
             f"{Emojis.ALARM_CLOCK.value} {str(self.remaining_time())} para el partido.\n\n"
             f"{Emojis.SOCCER_BALL.value} "
             f"<strong>{self.home_team.name} vs. {self.away_team.name}</strong>\n"
-            f"{Emojis.TROPHY.value} <strong>{self.championship.name}</strong>\n"
+            f"{Emojis.TROPHY.value} <strong>{self.championship.name}</strong>\n\n"
             f"{self.head_to_head_text()}"
             # f"{Emojis.LIGHT_BULB.value} Posible alineación del equipo:\n\n"
             # f"{self.line_up_message() if self.line_up else ''}\n\n"

--- a/src/entities.py
+++ b/src/entities.py
@@ -128,6 +128,7 @@ class Fixture:
     line_up: Optional[LineUp] = field(init=False)
     is_next_day: str = field(init=False)
     highlights: List[str] = field(init=False)
+    head_to_head: List["Fixture"] = field(init=False)
 
     def __post_init__(self) -> None:
         self.is_next_day = "(+1)" if self._is_next_day_in_europe() else ""
@@ -137,6 +138,7 @@ class Fixture:
         self.highlights = [
             f"https://www.youtube.com/results?search_query={self.home_team.name}+vs+{self.away_team.name}+jugadas+resumen"
         ]
+        self.head_to_head = []
 
     def remaining_time(self) -> RemainingTime:
         days = self.date_diff // 86400
@@ -169,6 +171,25 @@ class Fixture:
             f"{Emojis.ARGENTINA.value} <strong>{str(self.bsas_date)[11:16]} HS</strong>"
         )
 
+    def head_to_head_text(self) -> str:
+        h2h_text = ""
+
+        if self.head_to_head:
+            head_to_head_list = ""
+            for h2h_fixture in reversed(self.head_to_head[-5:]):
+                date_to_show = h2h_fixture.bsas_date.strftime("%Y-%m-%d")
+                head_to_head_list += (
+                    f"{Emojis.SPIRAL_CALENDAR.value} <strong>{date_to_show}</strong>\n"
+                    f"{Emojis.SOCCER_BALL.value} <strong>{h2h_fixture.home_team.name} [{h2h_fixture.match_score.home_score}] vs [{h2h_fixture.match_score.away_score}] {h2h_fixture.away_team.name}</strong>\n\n"
+                )
+
+            h2h_text = (
+                f"{Emojis.RIGHT_FACING_FIST.value}{Emojis.LEFT_FACING_FIST.value} Últimos enfrentamientos:\n\n"
+                f"{head_to_head_list}"
+            )
+
+        return h2h_text
+
     def one_line_telegram_repr(self, played: bool = False) -> str:
         if played:
             repr = (
@@ -183,7 +204,6 @@ class Fixture:
                 f"<strong>{self.home_team.name} vs. {self.away_team.name}</strong> \n"
                 f"{Emojis.TROPHY.value} <strong>{self.championship.name}</strong>\n"
                 f"{Emojis.ALARM_CLOCK.value} {self.time_telegram_text()}"
-
             )
 
         return repr
@@ -198,6 +218,7 @@ class Fixture:
             f"<img src='{self.away_team.picture}' width='22' height='22'></strong><br />"
             f"<img src='{self.championship.logo}' width='22' height='22'> <strong>{self.championship.name}</strong><br />"
             f"{Emojis.PUSHPIN.value} <strong>{self.round}</strong><p>"
+            f"{self.head_to_head_text()}"
             # f"{Emojis.LIGHT_BULB.value} Posible alineación del equipo:<p>"
             # f"{self.line_up_email_message()}<p>"
             f"{Emojis.TELEVISION.value} <a href='{self.futbol_libre_url}'>Streaming Online (FutbolLibre)</a><br />"
@@ -212,7 +233,7 @@ class Fixture:
             f"{Emojis.SOCCER_BALL.value} "
             f"<strong>{self.home_team.name} vs. {self.away_team.name}</strong>\n"
             f"{Emojis.TROPHY.value} <strong>{self.championship.name}</strong>\n"
-            f"{Emojis.PUSHPIN.value} <strong>{self.round}</strong>\n\n"
+            f"{self.head_to_head_text()}"
             # f"{Emojis.LIGHT_BULB.value} Posible alineación del equipo:\n\n"
             # f"{self.line_up_message() if self.line_up else ''}\n\n"
             f"{Emojis.TELEVISION.value} <a href='{self.futbol_libre_url}'>Streaming Online (FutbolLibre)</a>\n"

--- a/src/telegram_bot/bot_commands_handler.py
+++ b/src/telegram_bot/bot_commands_handler.py
@@ -141,7 +141,10 @@ class NotifierBotCommandsHandler:
 
         if len(tomorrow_games_fixtures):
             tomorrow_games_text = "\n\n".join(
-                [fixture.one_line_telegram_repr() for fixture in tomorrow_games_fixtures]
+                [
+                    fixture.one_line_telegram_repr()
+                    for fixture in tomorrow_games_fixtures
+                ]
             )
             tomorrow_games_text_intro = (
                 f"{Emojis.WAVING_HAND.value} Hola "

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -159,7 +159,7 @@ def get_today_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
 
 
 def insert_head_to_heads() -> Optional[List[Fixture]]:
-    tomorrow_games = FIXTURES_DB_MANAGER.get_tomorrow_games()
+    tomorrow_games = FIXTURES_DB_MANAGER.get_games_in_following_n_days(5)
 
     for game in tomorrow_games:
         head_to_head = FIXTURES_CLIENT.get_head_to_head(game.home_team, game.away_team)

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -12,6 +12,7 @@ from src.api.images_search_client import ImagesSearchClient
 from src.api.videos_search_client import VideosSearchClient
 from src.api.youtube_search_client import YoutubeSearchClient
 from src.db.db_manager import NotifierDBManager
+from src.db.fixtures_db_manager import FixturesDBManager
 from src.db.notif_sql_models import Fixture as DBFixture
 from src.db.notif_sql_models import League as DBLeague
 from src.db.notif_sql_models import Team as DBTeam
@@ -28,6 +29,10 @@ from src.entities import (
 )
 from src.utils.date_utils import TimeZones, get_formatted_date, get_time_in_time_zone
 from src.utils.message_utils import TEAMS_ALIASES
+
+
+FIXTURES_DB_MANAGER = FixturesDBManager()
+FIXTURES_CLIENT = FixturesClient()
 
 
 def get_team_aliases(team_id: str) -> list:
@@ -87,7 +92,15 @@ def get_next_fixture_db(team_fixtures: List[DBFixture]) -> Optional[DBFixture]:
             min_fixture = fixture
             min_diff = fixture_date_diff
 
-    return convert_db_fixture(min_fixture) if min_fixture else None
+    converted_fixture = None
+
+    if min_fixture:
+        converted_fixture = convert_db_fixture(min_fixture)
+        converted_fixture.head_to_head = get_head_to_heads(
+            converted_fixture.home_team.id, converted_fixture.away_team.id
+        )
+
+    return converted_fixture
 
 
 def get_last_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
@@ -105,7 +118,15 @@ def get_last_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
             min_fixture = fixture
             min_diff = fixture_date_diff
 
-    return convert_db_fixture(min_fixture) if min_fixture else None
+    converted_fixture = None
+
+    if min_fixture:
+        converted_fixture = convert_db_fixture(min_fixture)
+        converted_fixture.head_to_head = get_head_to_heads(
+            converted_fixture.home_team.id, converted_fixture.away_team.id
+        )
+
+    return converted_fixture
 
 
 def is_today_fixture(team_fixture: DBFixture) -> bool:
@@ -129,12 +150,35 @@ def is_tomorrow_fixture(team_fixture: DBFixture) -> bool:
     return bsas_date.date() == (datetime.today().date() + timedelta(days=1))
 
 
-def get_today_fixture_db(team_fixtures) -> Optional[Fixture]:
+def get_today_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
     for fixture in team_fixtures:
         if is_today_fixture(fixture):
             return convert_db_fixture(fixture)
 
     return None
+
+
+def insert_head_to_heads() -> Optional[List[Fixture]]:
+    tomorrow_games = FIXTURES_DB_MANAGER.get_tomorrow_games()
+
+    for game in tomorrow_games:
+        head_to_head = FIXTURES_CLIENT.get_head_to_head(game.home_team, game.away_team)
+        if "response" in head_to_head.as_dict:
+            head_to_head_fixtures = head_to_head.as_dict["response"]
+            if head_to_head_fixtures:
+                FIXTURES_DB_MANAGER.save_fixtures(
+                    [
+                        convert_fixture_response_to_db(fixture)
+                        for fixture in head_to_head_fixtures
+                    ]
+                )
+
+
+def get_head_to_heads(team_1: str, team_2: str) -> Optional[List[Fixture]]:
+    head_to_head_fixtures = FIXTURES_DB_MANAGER.get_head_to_head_fixtures(
+        team_1, team_2
+    )
+    return [convert_db_fixture(fixture) for fixture in head_to_head_fixtures]
 
 
 def get_yesterday_fixture_db(team_fixtures) -> Optional[Fixture]:
@@ -200,6 +244,9 @@ def __convert_standing_response(team_standing: dict) -> TeamStanding:
 
 
 def convert_db_fixture(fixture: DBFixture) -> Fixture:
+    """
+    Converts a fixture from database into a Fixture entity for notifying.
+    """
     utc_date = datetime.strptime(fixture.utc_date[:-6], "%Y-%m-%dT%H:%M:%S")
     ams_date = get_time_in_time_zone(utc_date, TimeZones.AMSTERDAM)
     bsas_date = get_time_in_time_zone(utc_date, TimeZones.BSAS)
@@ -472,9 +519,7 @@ def get_youtube_highlights_videos(
 
 
 def get_line_up(fixture_id: str, team_id: str) -> Optional[LineUp]:
-    fixture_client = FixturesClient()
-
-    response = fixture_client.get_line_up(fixture_id, team_id)
+    response = FIXTURES_CLIENT.get_line_up(fixture_id, team_id)
     json_response = response.as_dict["response"]
 
     line_up = None


### PR DESCRIPTION
Adding head to head records to `/next_match` notifications. Given that each fixture requires to be queried for grabbing the head to head matches, updater will only run everyday for the matches that are played the **next N days**, therefore:

- Refactoring database access and introducing FixturesDBManager, in order to make responsability more clear when accessing DB.
- Adding method for getting fixtures in next N days
- Adding utils functions for retrieving fixtures from database a query to RapidAPI the head to head for those fixtures and insert them in database.
- Adding head to head property to fixture entity in order to notify it properly.
- Updating Dockerfile, crontab and dev scripts accordingly