### PR TITLE
25 last today and tomorrow matches for specific tournaments

### DIFF
--- a/config/config_entities.py
+++ b/config/config_entities.py
@@ -18,4 +18,11 @@ class EmailRecipient:
 class ManagedTeam:
     id: str
     name: str
-    command_name: str
+    command: str
+
+
+@dataclass
+class ManagedLeague:
+    id: str
+    name: str
+    command: str

--- a/config/config_utils.py
+++ b/config/config_utils.py
@@ -2,11 +2,17 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from config.config_entities import EmailRecipient, ManagedTeam, TelegramRecipient
+from config.config_entities import (
+    EmailRecipient,
+    ManagedTeam,
+    TelegramRecipient,
+    ManagedLeague,
+)
 
 TELEGRAM_RECIPIENTS_FILE = Path(__file__).parent.absolute() / "telegram_recipients.json"
 EMAIL_RECIPIENTS_FILE = Path(__file__).parent.absolute() / "email_recipients.json"
 MANAGED_TEAMS_FILE = Path(__file__).parent.absolute() / "managed_teams.json"
+MANAGED_LEAGUES_FILE = Path(__file__).parent.absolute() / "managed_leagues.json"
 
 
 def get_json_file_data(file_path: Path) -> Dict[str, Any]:
@@ -40,7 +46,19 @@ def get_managed_teams_config() -> List[ManagedTeam]:
         ManagedTeam(
             managed_team["id"],
             managed_team["name"],
-            managed_team["command_name"],
+            managed_team["command"],
         )
         for managed_team in json_file_data
+    ]
+
+
+def get_managed_leagues_config() -> List[ManagedLeague]:
+    json_file_data = get_json_file_data(MANAGED_LEAGUES_FILE)
+    return [
+        ManagedLeague(
+            managed_league["id"],
+            managed_league["name"],
+            managed_league["command"],
+        )
+        for managed_league in json_file_data
     ]

--- a/config/managed_leagues.json
+++ b/config/managed_leagues.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "1",
+    "name": "World Cup",
+    "command": "world_cup"
+  },
+  {
+    "id": "2",
+    "name": "UEFA Champions League",
+    "command": "champions_league"
+  },
+  {
+    "id": "3",
+    "name": "UEFA Europa League",
+    "command": "europa_league"
+  },
+  {
+    "id": "5",
+    "name": "UEFA Nations League",
+    "command": "nations_league"
+  },
+  {
+    "id": "11",
+    "name": "CONMEBOL Sudamericana",
+    "command": "sudamericana"
+  },
+  {
+    "id": "13",
+    "name": "CONMEBOL Libertadores",
+    "command": "libertadores"
+  },
+  {
+    "id": "130",
+    "name": "Copa Argentina",
+    "command": "copa_argentina"
+  },
+  {
+    "id": "128",
+    "name": "Primera División",
+    "command": "primera_division"
+  },
+  {
+    "id": "39",
+    "name": "Premier League",
+    "command": "premier_league"
+  },
+  {
+    "id": "61",
+    "name": "League 1",
+    "command": "league_1"
+  },
+  {
+    "id": "135",
+    "name": "Serie A",
+    "command": "serie_a"
+  },
+  {
+    "id": "140",
+    "name": "La Liga",
+    "command": "la_liga"
+  }
+]

--- a/db_populator.py
+++ b/db_populator.py
@@ -1,16 +1,16 @@
-from datetime import date
+from datetime import date, datetime, timedelta
 from typing import List
 
-from config.config_utils import get_managed_teams_config
+from config.config_utils import get_managed_teams_config, get_managed_leagues_config
 from src.api.fixtures_client import FixturesClient
 from src.db.fixtures_db_manager import FixturesDBManager
 from src.entities import Fixture, FixtureForDB
 from src.notifier_logger import get_logger
-from src.team_fixtures_manager import TeamFixturesManager
 from src.utils.fixtures_utils import convert_fixture_response_to_db
 
 FIXTURES_DB_MANAGER = FixturesDBManager()
 MANAGED_TEAMS = get_managed_teams_config()
+MANAGED_LEAGUES = get_managed_leagues_config()
 
 logger = get_logger(__name__)
 
@@ -33,7 +33,17 @@ def get_converted_fixtures_to_db(fixtures: List[Fixture]) -> List[FixtureForDB]:
     return converted_fixtures
 
 
-def populate_data(is_initial=False) -> None:
+def populate_managed_teams() -> None:
+    for team in MANAGED_TEAMS:
+        FIXTURES_DB_MANAGER.insert_managed_team(team)
+
+
+def populate_managed_leagues() -> None:
+    for league in MANAGED_LEAGUES:
+        FIXTURES_DB_MANAGER.insert_managed_league(league)
+
+
+def populate_team_fixtures(is_initial) -> None:
     fixtures_client = FixturesClient()
     current_year = date.today().year
     last_year = current_year - 1
@@ -53,6 +63,37 @@ def populate_data(is_initial=False) -> None:
             FIXTURES_DB_MANAGER.save_fixtures(
                 get_converted_fixtures_to_db(team_fixtures.as_dict["response"])
             )
+
+
+def populate_league_fixtures() -> None:
+    fixtures_client = FixturesClient()
+    current_year = date.today().year
+    today = datetime.today()
+    yesterday_date = today + timedelta(days=-1)
+    tomorrow_date = today + timedelta(days=1)
+    from_date = yesterday_date.strftime("%Y-%m-%d")
+    to_date = tomorrow_date.strftime("%Y-%m-%d")
+
+    between_dates = (from_date, to_date)
+
+    for league in MANAGED_LEAGUES:
+        logger.info(f"Saving fixtures for league {league.name}")
+
+        league_fixtures = fixtures_client.get_fixtures_by(
+            str(current_year), league_id=league.id, between_dates=between_dates
+        )
+
+        if "response" in league_fixtures.as_dict:
+            FIXTURES_DB_MANAGER.save_fixtures(
+                get_converted_fixtures_to_db(league_fixtures.as_dict["response"])
+            )
+
+
+def populate_data(is_initial=False) -> None:
+    populate_managed_teams()
+    populate_managed_leagues()
+    populate_team_fixtures(is_initial)
+    populate_league_fixtures()
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8000:8000"
     env_file:
       - football_notifier.env
+    volumes:
+      - .:/usr/football_api
     depends_on:
       - db
     command: bash -c "dev_scripts/initialize_database.sh && dev_scripts/populate_database.sh && python -m pipenv run python /usr/football_api/notifier_bot.py"

--- a/partial_db_updater.py
+++ b/partial_db_updater.py
@@ -30,7 +30,10 @@ def update_fixtures() -> None:
         logger.info(f"Updating fixtures for lot {lot}")
         team_fixtures = fixtures_client.get_fixtures_by(ids=lot)
         FIXTURES_DB_MANAGER.save_fixtures(
-            [convert_fixture_response_to_db(fixture) for fixture in team_fixtures.as_dict["response"]]
+            [
+                convert_fixture_response_to_db(fixture)
+                for fixture in team_fixtures.as_dict["response"]
+            ]
         )
 
 

--- a/src/api/fixtures_client.py
+++ b/src/api/fixtures_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from src.api.base_client import BaseClient
 from src.notifier_logger import get_logger
@@ -13,7 +13,12 @@ class FixturesClient(BaseClient):
         self.request = APIRequest()
 
     def get_fixtures_by(
-        self, season: int = None, team_id: int = None, ids: List[int] = []
+        self,
+        season: int = None,
+        team_id: int = None,
+        ids: List[int] = [],
+        league_id: int = None,
+        between_dates: Tuple[str, str] = None,
     ) -> Dict[str, Any]:
         endpoint = "/v3/fixtures"
         params = {}
@@ -26,6 +31,13 @@ class FixturesClient(BaseClient):
 
         if len(ids):
             params["ids"] = "-".join([str(fix_id) for fix_id in ids])
+
+        if league_id:
+            params["league"] = league_id
+
+        if between_dates:
+            params["from"] = between_dates[0]
+            params["to"] = between_dates[1]
 
         url = f"{self.base_url}{endpoint}"
 

--- a/src/api/fixtures_client.py
+++ b/src/api/fixtures_client.py
@@ -41,6 +41,8 @@ class FixturesClient(BaseClient):
 
         url = f"{self.base_url}{endpoint}"
 
+        print(params)
+
         response = self.request.get(url, params, self.headers)
 
         logger.info(f"get_fixtures_by response - {response.status_code}")

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -23,17 +23,17 @@ class FixturesDBManager:
     def get_all_fixtures(self) -> List[Optional[DBFixture]]:
         return self._notifier_db_manager.select_records(select(DBFixture))
 
-    def get_games_in_following_n_days(self, days: int) -> List[Optional[DBFixture]]:
+    def get_games_in_surrounding_n_days(self, days: int) -> List[Optional[DBFixture]]:
         fixtures = []
 
         for day in range(1, days + 1):
             today = datetime.today()
             following_day = today + timedelta(days=day)
             bsas_date = get_time_in_time_zone(following_day, TimeZones.BSAS)
-            tomorrow_str = bsas_date.strftime("%Y-%m-%d")
+            games_date = bsas_date.strftime("%Y-%m-%d")
 
             statement = select(DBFixture).where(
-                DBFixture.utc_date.contains(tomorrow_str)
+                DBFixture.utc_date.contains(games_date)
             )
             fixtures = fixtures + self._notifier_db_manager.select_records(statement)
 

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -24,49 +24,28 @@ class FixturesDBManager:
         return self._notifier_db_manager.select_records(select(DBFixture))
 
     def get_games_in_surrounding_n_days(self, days: int) -> List[Optional[DBFixture]]:
-        fixtures = []
+        surrounding_fixtures = []
 
-        for day in range(1, days + 1):
+        if days > 0:
+            days_range = range(1, days)
+        elif days < 0:
+            days_range = range(days, 0)
+        else:
+            days_range = range(0, 1)
+
+        for day in days_range:
             today = datetime.today()
-            following_day = today + timedelta(days=day)
-            bsas_date = get_time_in_time_zone(following_day, TimeZones.BSAS)
-            games_date = bsas_date.strftime("%Y-%m-%d")
+            bsas_today = get_time_in_time_zone(today, TimeZones.BSAS)
+            surrounding_day = bsas_today + timedelta(days=day)
+            games_date = surrounding_day.strftime("%Y-%m-%d")
 
             statement = select(DBFixture).where(
-                DBFixture.utc_date.contains(games_date)
+                DBFixture.bsas_date.contains(games_date)
             )
-            fixtures = fixtures + self._notifier_db_manager.select_records(statement)
 
-        return fixtures
+            surrounding_fixtures += self._notifier_db_manager.select_records(statement)
 
-    def get_tomorrow_games(self) -> List[Optional[DBFixture]]:
-        today = datetime.today()
-        tomorrow = today + timedelta(days=1)
-        bsas_date = get_time_in_time_zone(tomorrow, TimeZones.BSAS)
-        tomorrow_str = bsas_date.strftime("%Y-%m-%d")
-
-        statement = select(DBFixture).where(DBFixture.utc_date.contains(tomorrow_str))
-
-        return self._notifier_db_manager.select_records(statement)
-
-    def get_today_games(self) -> List[Optional[DBFixture]]:
-        today = datetime.today()
-        bsas_date = get_time_in_time_zone(today, TimeZones.BSAS)
-        today_str = bsas_date.strftime("%Y-%m-%d")
-
-        statement = select(DBFixture).where(DBFixture.utc_date.contains(today_str))
-
-        return self._notifier_db_manager.select_records(statement)
-
-    def get_yesterday_games(self) -> List[Optional[DBFixture]]:
-        today = datetime.today()
-        yesterday = today - timedelta(days=1)
-        bsas_date = get_time_in_time_zone(yesterday, TimeZones.BSAS)
-        yesterday_str = bsas_date.strftime("%Y-%m-%d")
-
-        statement = select(DBFixture).where(DBFixture.utc_date.contains(yesterday_str))
-
-        return self._notifier_db_manager.select_records(statement)
+        return surrounding_fixtures
 
     def get_head_to_head_fixtures(self, team_1: str, team_2: str):
         statement = (
@@ -101,7 +80,8 @@ class FixturesDBManager:
             )
         else:
             logger.info(
-                f"Updating League '{fixture_league.name}' - it already exists in "
+                f"Updating League '{fixture_league.name}' - it already "
+                f"exists in "
                 f"the database"
             )
             db_league = retrieved_league.pop()
@@ -112,7 +92,8 @@ class FixturesDBManager:
 
         self._notifier_db_manager.insert_record(db_league)
 
-        # object needs to be queried again, as when we insert db_league we are closing the sessiona and then it's out of scope
+        # object needs to be queried again, as when we insert db_league we
+        # are closing the session and then it's out of scope
         # for later using it again
         return self._notifier_db_manager.select_records(league_statement)[0]
 
@@ -169,6 +150,7 @@ class FixturesDBManager:
                 db_fixture = DBFixture(
                     id=conv_fix.id,
                     utc_date=conv_fix.utc_date,
+                    bsas_date=conv_fix.bsas_date,
                     league=retrieved_league.id,
                     round=conv_fix.round,
                     home_team=retrieved_home_team.id,
@@ -184,6 +166,7 @@ class FixturesDBManager:
                 db_fixture = retrieved_fixture.pop()
                 db_fixture.id = conv_fix.id
                 db_fixture.utc_date = conv_fix.utc_date
+                db_fixture.bsas_date = conv_fix.bsas_date
                 db_fixture.league = retrieved_league.id
                 db_fixture.round = conv_fix.round
                 db_fixture.home_team = retrieved_home_team.id

--- a/src/db/notif_sql_models.py
+++ b/src/db/notif_sql_models.py
@@ -24,6 +24,7 @@ class Fixture(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
     id: int = Field(primary_key=True)
     utc_date: str
+    bsas_date: str
     league: int = Field(foreign_key="league.id")
     round: str
     home_team: int = Field(foreign_key="team.id")

--- a/src/db/notif_sql_models.py
+++ b/src/db/notif_sql_models.py
@@ -32,3 +32,17 @@ class Fixture(SQLModel, table=True):
     home_score: Optional[int] = None
     away_score: Optional[int] = None
     highlights: Optional[List[str]]
+
+
+class ManagedTeam(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    id: int = Field(primary_key=True)
+    name: str
+    command: str
+
+
+class ManagedLeague(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    id: int = Field(primary_key=True)
+    name: str
+    command: str

--- a/src/entities.py
+++ b/src/entities.py
@@ -101,6 +101,7 @@ class RemainingTime:
 class FixtureForDB:
     id: int
     utc_date: str
+    bsas_date: str
     date_diff: int
     referee: str
     match_status: str

--- a/src/telegram_bot/bot_commands_handler.py
+++ b/src/telegram_bot/bot_commands_handler.py
@@ -1,12 +1,17 @@
 import random
+from datetime import date
 from typing import List, Tuple
 
 
-from config.config_entities import ManagedTeam
 from config.config_utils import get_managed_teams_config
 from src.db.fixtures_db_manager import FixturesDBManager
-from src.db.notif_sql_models import Fixture
+from src.db.notif_sql_models import (
+    Fixture,
+    ManagedTeam as DBManagedTeam,
+    ManagedLeague as DBManagedLeague,
+)
 from src.emojis import Emojis
+from src.team_fixtures_manager import TeamFixturesManager
 from src.telegram_bot.bot_constants import MESSI_PHOTO
 from src.utils.fixtures_utils import (
     convert_db_fixture,
@@ -15,12 +20,23 @@ from src.utils.fixtures_utils import (
 
 class NotifierBotCommandsHandler:
     def __init__(self):
-        self._managed_teams: List[ManagedTeam] = get_managed_teams_config()
         self._fixtures_db_manager: FixturesDBManager = FixturesDBManager()
+        self._managed_teams: List[
+            DBManagedTeam
+        ] = self._fixtures_db_manager.get_managed_teams()
+        self._managed_leagues: List[
+            DBManagedLeague
+        ] = self._fixtures_db_manager.get_managed_leagues()
 
-    def get_managed_team(self, command_name: str) -> ManagedTeam:
+    def get_managed_team(self, command: str) -> DBManagedTeam:
         return next(
-            (team for team in self._managed_teams if team.command_name == command_name),
+            (team for team in self._managed_teams if team.command == command),
+            None,
+        )
+
+    def get_managed_league(self, command: str) -> DBManagedLeague:
+        return next(
+            (league for league in self._managed_leagues if league.command == command),
             None,
         )
 
@@ -28,11 +44,21 @@ class NotifierBotCommandsHandler:
         return any(
             managed_team
             for managed_team in self._managed_teams
-            if managed_team.command_name == team
+            if managed_team.command == team
+        )
+
+    def is_available_league(self, league: str) -> bool:
+        return any(
+            managed_league
+            for managed_league in self._managed_leagues
+            if managed_league.command == league
         )
 
     def available_command_team_names(self) -> List[str]:
-        return [managed_team.command_name for managed_team in self._managed_teams]
+        return [managed_team.command for managed_team in self._managed_teams]
+
+    def available_command_league_names(self) -> List[str]:
+        return [managed_league.command for managed_league in self._managed_leagues]
 
     def available_teams_text(self) -> str:
         return "\n".join(
@@ -42,12 +68,41 @@ class NotifierBotCommandsHandler:
             ]
         )
 
-    def _get_all_fixtures_ids(self, fixtures: List[Fixture]) -> List[str]:
-        return [fixture.id for fixture in fixtures]
+    def available_leagues_text(self) -> str:
+        return "\n".join(
+            [
+                f"• {available_league}"
+                for available_league in self.available_command_league_names()
+            ]
+        )
 
-    def today_games(self, user_name: str) -> Tuple[str, str]:
+
+class SurroundingMatchesHandler(NotifierBotCommandsHandler):
+    def __init__(self, commands_args: List[str], user: str):
+        super().__init__()
+        self._command_args = commands_args
+        self._user = user
+        self._league = ""
+
+    def validate_command_input(self) -> str:
+        response = ""
+
+        if len(self._command_args) == 1:
+            self._league = self._command_args[0].lower()
+        elif len(self._command_args) > 1:
+            response = "Sólo puedes ingresar uno (torneo) o ningún paramétro."
+        else:
+            pass
+
+        return response
+
+    def today_games(self) -> Tuple[str, str]:
         today_games_fixtures = (
-            self._fixtures_db_manager.get_games_in_surrounding_n_days(0)
+            self._fixtures_db_manager.get_games_in_surrounding_n_days(0, self._league)
+        )
+
+        league_text = (
+            f" en {self.get_managed_league(self._league).name}" if self._league else ""
         )
 
         if len(today_games_fixtures):
@@ -59,8 +114,8 @@ class NotifierBotCommandsHandler:
             )
             today_games_text_intro = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, "
-                f"estos son los partidos de hoy:\n\n"
+                f"{self._user}, "
+                f"estos son los partidos de hoy{league_text}:\n\n"
             )
             text = f"{today_games_text_intro}{today_games_text}"
             leagues = [fixture.championship for fixture in converted_games]
@@ -68,18 +123,21 @@ class NotifierBotCommandsHandler:
         else:
             text = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, lamentablemente hoy "
-                f"no hay partidos :("
+                f"{self._user}, lamentablemente hoy "
+                f"no hay partidos{league_text} :("
             )
             photo = MESSI_PHOTO
 
         return (text, photo)
 
-    def yesterday_games(self, user_name: str) -> Tuple[str, str]:
+    def yesterday_games(self) -> Tuple[str, str]:
         played_games_fixtures = (
-            self._fixtures_db_manager.get_games_in_surrounding_n_days(-1)
+            self._fixtures_db_manager.get_games_in_surrounding_n_days(-1, self._league)
         )
 
+        league_text = (
+            f"en {self.get_managed_league(self._league).name}" if self._league else ""
+        )
         if len(played_games_fixtures):
             converted_fixtures = [
                 convert_db_fixture(fixture) for fixture in played_games_fixtures
@@ -92,9 +150,9 @@ class NotifierBotCommandsHandler:
             )
             played_games_text_intro = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, "
+                f"{self._user}, "
                 f"estos son los partidos jugados "
-                f"ayer:\n\n"
+                f"ayer{league_text}:\n\n"
             )
             text = f"{played_games_text_intro}{played_games_text}"
             leagues = [fixture.championship for fixture in converted_fixtures]
@@ -102,18 +160,21 @@ class NotifierBotCommandsHandler:
         else:
             text = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, lamentablemente "
-                f"ayer no se jugaron partidos :("
+                f"{self._user}, lamentablemente "
+                f"ayer no se jugaron partidos{league_text} :("
             )
             photo = MESSI_PHOTO
 
         return (text, photo)
 
-    def tomorrow_games(self, user_name: str) -> Tuple[str, str]:
+    def tomorrow_games(self) -> Tuple[str, str]:
         tomorrow_games_fixtures = (
-            self._fixtures_db_manager.get_games_in_surrounding_n_days(1)
+            self._fixtures_db_manager.get_games_in_surrounding_n_days(1, self._league)
         )
 
+        league_text = (
+            f" en {self.get_managed_league(self._league).name}" if self._league else ""
+        )
         if len(tomorrow_games_fixtures):
             converted_fixtures = [
                 convert_db_fixture(fixture) for fixture in tomorrow_games_fixtures
@@ -123,8 +184,8 @@ class NotifierBotCommandsHandler:
             )
             tomorrow_games_text_intro = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, "
-                f"estos son los partidos de mañana:\n\n"
+                f"{self._user}, "
+                f"estos son los partidos de mañana{league_text}:\n\n"
             )
             text = f"{tomorrow_games_text_intro}{tomorrow_games_text}"
             leagues = [fixture.championship for fixture in converted_fixtures]
@@ -132,8 +193,8 @@ class NotifierBotCommandsHandler:
         else:
             text = (
                 f"{Emojis.WAVING_HAND.value} Hola "
-                f"{user_name}, lamentablemente mañana "
-                f"no hay partidos :("
+                f"{self._user}, lamentablemente mañana "
+                f"no hay partidos{league_text} :("
             )
             photo = MESSI_PHOTO
 
@@ -141,9 +202,10 @@ class NotifierBotCommandsHandler:
 
 
 class NextAndLastMatchCommandHandler(NotifierBotCommandsHandler):
-    def __init__(self, commands_args: List[str]):
+    def __init__(self, commands_args: List[str], user: str):
         super().__init__()
         self._command_args = commands_args
+        self._user = user
 
     def validate_command_input(self) -> str:
         response = ""
@@ -162,3 +224,19 @@ class NextAndLastMatchCommandHandler(NotifierBotCommandsHandler):
                 )
 
         return response
+
+    def next_match_team_notif(self) -> Tuple[str, str]:
+        team_name = self._command_args[0].lower()
+        team = self.get_managed_team(team_name)
+        current_season = date.today().year
+        team_fixtures_manager = TeamFixturesManager(current_season, team.id)
+
+        return team_fixtures_manager.get_next_team_fixture_text(self._user)
+
+    def last_match_team_notif(self) -> Tuple[str, str]:
+        team_name = self._command_args[0].lower()
+        team = self.get_managed_team(team_name)
+        current_season = date.today().year
+        team_fixtures_manager = TeamFixturesManager(current_season, team.id)
+
+        return team_fixtures_manager.get_last_team_fixture_text(self._user)

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -136,28 +136,6 @@ def is_today_fixture(team_fixture: DBFixture) -> bool:
     return bsas_date.date() == datetime.today().date()
 
 
-def is_yesterday_fixture(team_fixture: DBFixture) -> bool:
-    utc_date = datetime.strptime(team_fixture.utc_date[:-6], "%Y-%m-%dT%H:%M:%S")
-    bsas_date = get_time_in_time_zone(utc_date, TimeZones.BSAS)
-
-    return bsas_date.date() == (datetime.today().date() - timedelta(days=1))
-
-
-def is_tomorrow_fixture(team_fixture: DBFixture) -> bool:
-    utc_date = datetime.strptime(team_fixture.utc_date[:-6], "%Y-%m-%dT%H:%M:%S")
-    bsas_date = get_time_in_time_zone(utc_date, TimeZones.BSAS)
-
-    return bsas_date.date() == (datetime.today().date() + timedelta(days=1))
-
-
-def get_today_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
-    for fixture in team_fixtures:
-        if is_today_fixture(fixture):
-            return convert_db_fixture(fixture)
-
-    return None
-
-
 def insert_head_to_heads() -> Optional[List[Fixture]]:
     tomorrow_games = FIXTURES_DB_MANAGER.get_games_in_surrounding_n_days(5)
 
@@ -179,22 +157,6 @@ def get_head_to_heads(team_1: str, team_2: str) -> Optional[List[Fixture]]:
         team_1, team_2
     )
     return [convert_db_fixture(fixture) for fixture in head_to_head_fixtures]
-
-
-def get_yesterday_fixture_db(team_fixtures) -> Optional[Fixture]:
-    for fixture in team_fixtures:
-        if is_yesterday_fixture(fixture):
-            return convert_db_fixture(fixture)
-
-    return None
-
-
-def get_tomorrow_fixture_db(team_fixtures) -> Optional[Fixture]:
-    for fixture in team_fixtures:
-        if is_tomorrow_fixture(fixture):
-            return convert_db_fixture(fixture)
-
-    return None
 
 
 def get_last_fixture(
@@ -347,9 +309,15 @@ def convert_fixture_response_to_db(fixture_response: Dict[str, Any]) -> Fixture:
     home_team_id = fixture_response["teams"]["home"]["id"]
     away_team_id = fixture_response["teams"]["away"]["id"]
 
+    utc_date = datetime.strptime(
+        fixture_response["fixture"]["date"][:-6], "%Y-%m-%dT%H:%M:%S"
+    )
+    bsas_date = get_time_in_time_zone(utc_date, TimeZones.BSAS)
+
     return FixtureForDB(
         fixture_response["fixture"]["id"],
         fixture_response["fixture"]["date"],
+        datetime.strftime(bsas_date, "%Y-%m-%dT%H:%M:%S"),
         date_diff,
         fixture_response["fixture"]["referee"],
         fixture_response["fixture"]["status"]["long"],

--- a/src/utils/fixtures_utils.py
+++ b/src/utils/fixtures_utils.py
@@ -159,7 +159,7 @@ def get_today_fixture_db(team_fixtures: List[DBFixture]) -> Optional[Fixture]:
 
 
 def insert_head_to_heads() -> Optional[List[Fixture]]:
-    tomorrow_games = FIXTURES_DB_MANAGER.get_games_in_following_n_days(5)
+    tomorrow_games = FIXTURES_DB_MANAGER.get_games_in_surrounding_n_days(5)
 
     for game in tomorrow_games:
         head_to_head = FIXTURES_CLIENT.get_head_to_head(game.home_team, game.away_team)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -66,42 +66,6 @@ def test_date_conversion():
     assert bsas_definitive_date
 
 
-def test_is_today_fixture():
-    with freeze_time("2022-06-19 10:30:00"):
-        river_fixture = MagicMock(
-            id=863211,
-            utc_date="2022-06-19T21:00:00+00:00",
-            league=128,
-            round="2ª Fase - 4",
-            home_team=441,
-            away_team=435,
-            home_score=1,
-            away_score=5,
-        )
-
-        is_today_bsas_fixture = is_today_fixture(river_fixture)
-
-        assert True == is_today_bsas_fixture
-
-
-def test_is_today_fixture_false():
-    with freeze_time("2022-06-18 02:30:00"):
-        river_fixture = MagicMock(
-            id=863211,
-            utc_date="2022-06-19T21:00:00+00:00",
-            league=128,
-            round="2ª Fase - 4",
-            home_team=441,
-            away_team=435,
-            home_score=1,
-            away_score=5,
-        )
-
-        is_today_bsas_fixture = is_today_fixture(river_fixture)
-
-        assert False == is_today_bsas_fixture
-
-
 def test_get_date_spanish_text_format():
     # given
     date = datetime.strptime("2021-10-29T18:45:00", "%Y-%m-%dT%H:%M:%S")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,12 +1,10 @@
 import os
 from datetime import datetime
-from unittest.mock import MagicMock
-
 import pytz
 from freezegun import freeze_time
 
 from src.utils.date_utils import get_date_spanish_text_format
-from src.utils.fixtures_utils import date_diff, get_next_fixture, is_today_fixture
+from src.utils.fixtures_utils import date_diff, get_next_fixture
 from tests.utils.sample_data_utils import get_sample_data_response
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Adding functionality for getting surrounding fixtures for a specific league/tournament.

- Adding `ManagedTeam` and `ManagedLeague` entities in database.
- Adding daily update of surrounding league fixture at `db_populator.py`
- Adding command handlers at telegram bot