### PR TITLE
28 possibility to query more for leagues teams

### DIFF
--- a/notifier_bot.py
+++ b/notifier_bot.py
@@ -11,6 +11,7 @@ from src.telegram_bot.bot_commands_handler import (
     NextAndLastMatchCommandHandler,
     NotifierBotCommandsHandler,
     SurroundingMatchesHandler,
+    NextAndLastMatchLeagueCommandHandler,
 )
 from src.telegram_bot.bot_constants import MESSI_PHOTO
 
@@ -36,6 +37,8 @@ async def help(update: Update, context):
         f" {Emojis.JOYSTICK.value} Estos son mis comandos disponibles (por ahora):\n\n"
         f"• /next_match <team>: próximo partido del equipo.\n"
         f"• /last_match <team>: último partido jugado del equipo.\n"
+        f"• /next_match_league <tournament>: próximo partido del torneo seleccionado.\n"
+        f"• /last_match_league <tournament>: último partido jugado del torneo seleccionado.\n"
         f"• /available_teams: equipos disponibles para consultar.\n"
         f"• /available_leagues: torneos disponibles para consultar.\n"
         f"• /today_matches [opt]<league>: partidos de hoy (de los equipos disponibles).\n"
@@ -111,6 +114,61 @@ async def last_match(update: Update, context):
         )
     else:
         text, photo = command_handler.last_match_team_notif()
+        logger.info(f"Fixture - text: {text} - photo: {photo}")
+        if photo:
+            await context.bot.send_photo(
+                chat_id=update.effective_chat.id,
+                photo=photo,
+                caption=text,
+                parse_mode="HTML",
+            )
+        else:
+            context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+
+
+async def next_match_league(update: Update, context):
+    logger.info(
+        f"'next_match_league {' '.join(context.args)}' command executed - by {update.effective_user.name}"
+    )
+    command_handler = NextAndLastMatchLeagueCommandHandler(
+        context.args, update.effective_user.first_name
+    )
+
+    validated_input = command_handler.validate_command_input()
+
+    if validated_input:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=validated_input
+        )
+    else:
+        text, photo = command_handler.next_match_league_notif()
+        logger.info(f"Fixture - text: {text} - photo: {photo}")
+        if photo:
+            await context.bot.send_photo(
+                chat_id=update.effective_chat.id,
+                photo=photo,
+                caption=text,
+                parse_mode="HTML",
+            )
+        else:
+            context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+
+
+async def last_match_league(update: Update, context):
+    logger.info(
+        f"'last_match_league {' '.join(context.args)}' command executed - by {update.effective_user.first_name}"
+    )
+    command_handler = NextAndLastMatchLeagueCommandHandler(
+        context.args, update.effective_user.first_name
+    )
+    validated_input = command_handler.validate_command_input()
+
+    if validated_input:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=validated_input
+        )
+    else:
+        text, photo = command_handler.last_match_league_notif()
         logger.info(f"Fixture - text: {text} - photo: {photo}")
         if photo:
             await context.bot.send_photo(
@@ -200,6 +258,8 @@ if __name__ == "__main__":
     start_handler = CommandHandler("start", start)
     next_match_handler = CommandHandler("next_match", next_match)
     last_match_handler = CommandHandler("last_match", last_match)
+    next_match_league_handler = CommandHandler("next_match_league", next_match_league)
+    last_match_league_handler = CommandHandler("last_match_league", last_match_league)
     today_matches_handler = CommandHandler("today_matches", today_matches)
     tomorrow_matches_handler = CommandHandler("tomorrow_matches", tomorrow_matches)
     last_played_matches_handler = CommandHandler(
@@ -212,6 +272,8 @@ if __name__ == "__main__":
     application.add_handler(start_handler)
     application.add_handler(next_match_handler)
     application.add_handler(last_match_handler)
+    application.add_handler(next_match_league_handler)
+    application.add_handler(last_match_league_handler)
     application.add_handler(help_handler)
     application.add_handler(today_matches_handler)
     application.add_handler(last_played_matches_handler)

--- a/notifier_bot.py
+++ b/notifier_bot.py
@@ -38,6 +38,7 @@ async def help(update: Update, context):
         f"• /next_match <team>: próximo partido del equipo.\n"
         f"• /last_match <team>: último partido jugado del equipo.\n"
         f"• /next_match_league <tournament>: próximo partido del torneo seleccionado.\n"
+        f"• /next_matches_league <tournament>: Partidos del día de los próximos partidos del torneo seleccionado.\n"
         f"• /last_match_league <tournament>: último partido jugado del torneo seleccionado.\n"
         f"• /available_teams: equipos disponibles para consultar.\n"
         f"• /available_leagues: torneos disponibles para consultar.\n"
@@ -154,6 +155,26 @@ async def next_match_league(update: Update, context):
             context.bot.send_message(chat_id=update.effective_chat.id, text=text)
 
 
+async def next_matches_league(update: Update, context):
+    logger.info(
+        f"'next_matches_league {' '.join(context.args)}' command executed - by {update.effective_user.name}"
+    )
+    command_handler = NextAndLastMatchLeagueCommandHandler(
+        context.args, update.effective_user.first_name
+    )
+
+    validated_input = command_handler.validate_command_input()
+
+    if validated_input:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=validated_input
+        )
+    else:
+        text = command_handler.next_matches_league_notif()
+        logger.info(f"Fixture - text: {text}")
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=text, parse_mode="HTML")
+
+
 async def last_match_league(update: Update, context):
     logger.info(
         f"'last_match_league {' '.join(context.args)}' command executed - by {update.effective_user.first_name}"
@@ -259,6 +280,7 @@ if __name__ == "__main__":
     next_match_handler = CommandHandler("next_match", next_match)
     last_match_handler = CommandHandler("last_match", last_match)
     next_match_league_handler = CommandHandler("next_match_league", next_match_league)
+    next_matches_league_handler = CommandHandler("next_matches_league", next_matches_league)
     last_match_league_handler = CommandHandler("last_match_league", last_match_league)
     today_matches_handler = CommandHandler("today_matches", today_matches)
     tomorrow_matches_handler = CommandHandler("tomorrow_matches", tomorrow_matches)
@@ -273,6 +295,7 @@ if __name__ == "__main__":
     application.add_handler(next_match_handler)
     application.add_handler(last_match_handler)
     application.add_handler(next_match_league_handler)
+    application.add_handler(next_matches_league_handler)
     application.add_handler(last_match_league_handler)
     application.add_handler(help_handler)
     application.add_handler(today_matches_handler)

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -77,8 +77,12 @@ class FixturesDBManager:
         )
         return self._notifier_db_manager.select_records(fixtures_statement)
 
-    def get_fixtures_by_league(self, league_id: int) -> Optional[List[DBFixture]]:
+    def get_fixtures_by_league(self, league_id: int, date: str = "") -> Optional[List[DBFixture]]:
         fixtures_statement = select(DBFixture).where(DBFixture.league == league_id)
+
+        if date:
+            fixtures_statement = fixtures_statement.where(DBFixture.bsas_date.contains(date))
+
         return self._notifier_db_manager.select_records(fixtures_statement)
 
     def get_next_fixture(

--- a/src/telegram_bot/bot_commands_handler.py
+++ b/src/telegram_bot/bot_commands_handler.py
@@ -1,4 +1,5 @@
 import random
+from datetime import datetime
 from typing import List, Tuple
 
 from src.db.fixtures_db_manager import FixturesDBManager
@@ -9,6 +10,7 @@ from src.db.notif_sql_models import (
 )
 from src.emojis import Emojis
 from src.telegram_bot.bot_constants import MESSI_PHOTO
+from src.utils.date_utils import get_date_spanish_text_format
 from src.utils.fixtures_utils import (
     convert_db_fixture,
     get_head_to_heads,
@@ -77,6 +79,26 @@ class NotifierBotCommandsHandler:
                 f"• {available_league}"
                 for available_league in self.available_command_league_names()
             ]
+        )
+
+    @staticmethod
+    def get_fixtures_text(
+        converted_fixtures: List[Fixture], played=False
+    ) -> List[str]:
+        text_limit = 3950
+        fixtures_text = ""
+        fitting_fixtures = []
+
+        for fixture in converted_fixtures:
+            fixture_text = fixture.one_line_telegram_repr(played)
+
+            if len(f"{fixtures_text}\n\n{fixture_text}") > text_limit:
+                break
+            else:
+                fitting_fixtures.append(fixture)
+
+        return "\n\n".join(
+            [fixture.one_line_telegram_repr(played) for fixture in fitting_fixtures]
         )
 
 
@@ -170,6 +192,7 @@ class SurroundingMatchesHandler(NotifierBotCommandsHandler):
         )
 
         league_text = f" en {self._managed_league.name}" if self._managed_league else ""
+
         if len(tomorrow_games_fixtures):
             converted_fixtures = [
                 convert_db_fixture(fixture) for fixture in tomorrow_games_fixtures
@@ -193,24 +216,6 @@ class SurroundingMatchesHandler(NotifierBotCommandsHandler):
 
         return (text, photo)
 
-    def get_fixtures_text(
-        self, converted_fixtures: List[Fixture], played=False
-    ) -> List[str]:
-        text_limit = 3950
-        fixtures_text = ""
-        fitting_fixtures = []
-
-        for fixture in converted_fixtures:
-            fixture_text = fixture.one_line_telegram_repr(played)
-
-            if len(f"{fixtures_text}\n\n{fixture_text}") > text_limit:
-                break
-            else:
-                fitting_fixtures.append(fixture)
-
-        return "\n\n".join(
-            [fixture.one_line_telegram_repr(played) for fixture in fitting_fixtures]
-        )
 
 
 class NextAndLastMatchCommandHandler(NotifierBotCommandsHandler):
@@ -335,3 +340,36 @@ class NextAndLastMatchLeagueCommandHandler(NotifierBotCommandsHandler):
         return telegram_last_fixture_league_notification(
             converted_fixture, league.name, self._user
         )
+
+    def next_matches_league_notif(self) -> str:
+        league_name = self._command_args[0].lower()
+        league = self.get_managed_league(league_name)
+
+        next_league_db_fixture = self._fixtures_db_manager.get_next_fixture(
+            league_id=league.id
+        )
+
+        if next_league_db_fixture:
+            next_match_date = next_league_db_fixture.bsas_date[:10]
+            next_matches = self._fixtures_db_manager.get_fixtures_by_league(league.id, next_match_date)
+
+            converted_fixtures = [
+                convert_db_fixture(fixture) for fixture in
+                next_matches
+            ]
+
+            spanish_format_date = get_date_spanish_text_format(converted_fixtures[0].bsas_date)
+
+            match_date = (
+                "HOY!"
+                if converted_fixtures[0].bsas_date.date() == datetime.today().date()
+                else f"el {spanish_format_date}"
+            )
+
+            telegram_message = (
+                f"{Emojis.WAVING_HAND.value}Hola {self._user}! "
+                f"\n\nLos próximos partidos de <strong>{league.name}</strong> son {match_date}\n\n"
+                f"{self.get_fixtures_text(converted_fixtures)}"
+            )
+
+        return telegram_message

--- a/src/utils/notification_text_utils.py
+++ b/src/utils/notification_text_utils.py
@@ -1,0 +1,129 @@
+from datetime import datetime
+import random
+from typing import List
+
+from src.db.fixtures_db_manager import FixturesDBManager
+from src.emojis import Emojis
+from src.entities import Fixture
+from src.utils.date_utils import get_date_spanish_text_format
+
+
+FIXTURES_DB_MANAGER = FixturesDBManager()
+
+
+def telegram_last_fixture_team_notification(
+    team_fixture: Fixture, team: str, user: str = ""
+) -> tuple:
+    match_images = _get_match_images(team_fixture)
+    match_image_url = random.choice(match_images)
+    spanish_format_date = get_date_spanish_text_format(team_fixture.bsas_date)
+
+    highlights_yt_url = (
+        f"https://www.youtube.com/results?search_query="
+        f"{team_fixture.home_team.name}+vs+{team_fixture.away_team.name}+jugadas+resumen"
+    )
+
+    highlights_text = (
+        f"{Emojis.FILM_PROJECTOR.value} <a href='{highlights_yt_url}'>HIGHLIGHTS</a>"
+    )
+
+    match_date = (
+        "HOY!"
+        if team_fixture.bsas_date.date() == datetime.today().date()
+        else f"el {spanish_format_date}"
+    )
+
+    telegram_message = (
+        f"{Emojis.WAVING_HAND.value}Hola {user}!\n\n"
+        f"{team} jugó {match_date} \n\n"
+        f"{team_fixture.matched_played_telegram_like_repr()}"
+        f"{highlights_text}"
+    )
+
+    return (telegram_message, match_image_url)
+
+
+def telegram_last_fixture_league_notification(
+    team_fixture: Fixture, league: str, user: str = ""
+) -> tuple:
+    match_images = _get_match_images(team_fixture)
+    match_image_url = random.choice(match_images)
+    spanish_format_date = get_date_spanish_text_format(team_fixture.bsas_date)
+
+    highlights_yt_url = (
+        f"https://www.youtube.com/results?search_query="
+        f"{team_fixture.home_team.name}+vs+{team_fixture.away_team.name}+jugadas+resumen"
+    )
+
+    highlights_text = (
+        f"{Emojis.FILM_PROJECTOR.value} <a href='{highlights_yt_url}'>HIGHLIGHTS</a>"
+    )
+
+    match_date = (
+        "HOY!"
+        if team_fixture.bsas_date.date() == datetime.today().date()
+        else f"el {spanish_format_date}"
+    )
+
+    telegram_message = (
+        f"{Emojis.WAVING_HAND.value}Hola {user}!\n\n"
+        f"El último partido de {league} fué {match_date} \n\n"
+        f"{team_fixture.matched_played_telegram_like_repr()}"
+        f"{highlights_text}"
+    )
+
+    return (telegram_message, match_image_url)
+
+
+def telegram_next_team_fixture_notification(
+    team_fixture: Fixture, team: str, user: str = ""
+) -> tuple:
+    spanish_format_date = get_date_spanish_text_format(team_fixture.bsas_date)
+    match_images = _get_match_images(team_fixture)
+    match_image_url = random.choice(match_images)
+
+    match_date = (
+        "HOY!"
+        if team_fixture.bsas_date.date() == datetime.today().date()
+        else f"el {spanish_format_date}"
+    )
+
+    telegram_message = (
+        f"{Emojis.WAVING_HAND.value}Hola {user}! "
+        f"\n\nEl próximo partido de {team} es {match_date}\n\n"
+        f"{team_fixture.telegram_like_repr()}"
+    )
+
+    return (telegram_message, match_image_url)
+
+
+def telegram_next_league_fixture_notification(
+    team_fixture: Fixture, league: str, user: str = ""
+) -> tuple:
+    spanish_format_date = get_date_spanish_text_format(team_fixture.bsas_date)
+    match_images = _get_match_images(team_fixture)
+    match_image_url = random.choice(match_images)
+
+    match_date = (
+        "HOY!"
+        if team_fixture.bsas_date.date() == datetime.today().date()
+        else f"el {spanish_format_date}"
+    )
+
+    telegram_message = (
+        f"{Emojis.WAVING_HAND.value}Hola {user}! "
+        f"\n\nEl próximo partido de {league} es {match_date}\n\n"
+        f"{team_fixture.telegram_like_repr()}"
+    )
+
+    return (telegram_message, match_image_url)
+
+
+def _get_match_images(fixture: Fixture) -> List[str]:
+    home_team_image_url = FIXTURES_DB_MANAGER.get_team(fixture.home_team.id)[0].picture
+    away_team_image_url = FIXTURES_DB_MANAGER.get_team(fixture.away_team.id)[0].picture
+    league_image_url = FIXTURES_DB_MANAGER.get_league(fixture.championship.league_id)[
+        0
+    ].logo
+
+    return [home_team_image_url, away_team_image_url, league_image_url]

--- a/tests/test_partial_db_updater.py
+++ b/tests/test_partial_db_updater.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from db_populator import get_fixture_update_lots
+from partial_db_updater import get_fixture_update_lots
 
 current_path = Path(__file__).parent.absolute()
 env_file = current_path / ".." / "football_notifier.env"


### PR DESCRIPTION
Adding functionality for three new commands:

- `/next_match_league`: Informs the next fixture happening in the selected league
- `/last_match_league`: Informs the last fixture that happened in the selected league
- `/next_matches_league`: Informs the fixtures corresponding to the date when the next match is happening in the selected league