### PR TITLE
27 get rid of managed teams leagues

### DIFF
--- a/notifier_bot.py
+++ b/notifier_bot.py
@@ -12,6 +12,7 @@ from src.telegram_bot.bot_commands_handler import (
     NotifierBotCommandsHandler,
     SurroundingMatchesHandler,
     NextAndLastMatchLeagueCommandHandler,
+    SearchTeamCommandHandler,
 )
 from src.telegram_bot.bot_constants import MESSI_PHOTO
 
@@ -71,6 +72,25 @@ async def available_leagues(update: Update, context):
         f"{notifier_commands_handler.available_leagues_text()}"
     )
     await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+
+
+async def search_team(update: Update, context):
+    logger.info(
+        f"'search_team {' '.join(context.args)}' command executed - by {update.effective_user.name}"
+    )
+    command_handler = SearchTeamCommandHandler(
+        context.args, update.effective_user.first_name
+    )
+    validated_input = command_handler.validate_command_input()
+
+    if validated_input:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=validated_input
+        )
+    else:
+        text = command_handler.next_match_team_notif()
+        logger.info(f"Search Team - text: {text}")
+        context.bot.send_message(chat_id=update.effective_chat.id, text=text)
 
 
 async def next_match(update: Update, context):
@@ -172,7 +192,9 @@ async def next_matches_league(update: Update, context):
     else:
         text = command_handler.next_matches_league_notif()
         logger.info(f"Fixture - text: {text}")
-        await context.bot.send_message(chat_id=update.effective_chat.id, text=text, parse_mode="HTML")
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=text, parse_mode="HTML"
+        )
 
 
 async def last_match_league(update: Update, context):
@@ -277,10 +299,13 @@ async def tomorrow_matches(update: Update, context):
 if __name__ == "__main__":
     application = ApplicationBuilder().token(NotifConfig.TELEGRAM_TOKEN).build()
     start_handler = CommandHandler("start", start)
+    search_team_handler = CommandHandler("search_team", search_team)
     next_match_handler = CommandHandler("next_match", next_match)
     last_match_handler = CommandHandler("last_match", last_match)
     next_match_league_handler = CommandHandler("next_match_league", next_match_league)
-    next_matches_league_handler = CommandHandler("next_matches_league", next_matches_league)
+    next_matches_league_handler = CommandHandler(
+        "next_matches_league", next_matches_league
+    )
     last_match_league_handler = CommandHandler("last_match_league", last_match_league)
     today_matches_handler = CommandHandler("today_matches", today_matches)
     tomorrow_matches_handler = CommandHandler("tomorrow_matches", tomorrow_matches)
@@ -303,5 +328,6 @@ if __name__ == "__main__":
     application.add_handler(available_teams_handler)
     application.add_handler(tomorrow_matches_handler)
     application.add_handler(available_leagues_handler)
+    application.add_handler(search_team_handler)
 
     application.run_polling()

--- a/notifier_bot.py
+++ b/notifier_bot.py
@@ -12,7 +12,7 @@ from src.telegram_bot.bot_commands_handler import (
     NotifierBotCommandsHandler,
     SurroundingMatchesHandler,
     NextAndLastMatchLeagueCommandHandler,
-    SearchTeamCommandHandler,
+    SearchTeamLeagueCommandHandler,
 )
 from src.telegram_bot.bot_constants import MESSI_PHOTO
 
@@ -36,27 +36,17 @@ async def help(update: Update, context):
     text = (
         f"{Emojis.WAVING_HAND.value}Hola {update.effective_user.first_name}!\n\n"
         f" {Emojis.JOYSTICK.value} Estos son mis comandos disponibles (por ahora):\n\n"
+        f"• /search_team <team_name>: permite realizar una búsqueda de los equipos existentes y sus respectivos ids para ser usado en el resto de los comandos. \n"
+        f"• /search_league <league_name>: permite realizar una búsqueda los torneos existentes y sus respectivos ids para ser usado en el resto de los comandos. \n"
         f"• /next_match <team>: próximo partido del equipo.\n"
         f"• /last_match <team>: último partido jugado del equipo.\n"
-        f"• /next_match_league <tournament>: próximo partido del torneo seleccionado.\n"
-        f"• /next_matches_league <tournament>: Partidos del día de los próximos partidos del torneo seleccionado.\n"
-        f"• /last_match_league <tournament>: último partido jugado del torneo seleccionado.\n"
-        f"• /available_teams: equipos disponibles para consultar.\n"
-        f"• /available_leagues: torneos disponibles para consultar.\n"
-        f"• /today_matches [opt]<league>: partidos de hoy (de los equipos disponibles).\n"
-        f"• /tomorrow_matches [opt]<league>: partidos de mañana (de los equipos disponibles).\n"
-        f"• /last_played_matches [opt]<league>: partidos jugados el día de ayer (de los equipos disponibles)."
-    )
-    await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
-
-
-async def available_teams(update: Update, context):
-    logger.info(f"'available_teams' command executed - by {update.effective_user.name}")
-    notifier_commands_handler = NotifierBotCommandsHandler()
-    text = (
-        f"{Emojis.WAVING_HAND.value}Hola {update.effective_user.first_name}!\n\n"
-        f" {Emojis.TELEVISION.value} Estos son los equipos disponibles:\n\n"
-        f"{notifier_commands_handler.available_teams_text()}"
+        f"• /next_match_league <league_id>: próximo partido del torneo seleccionado.\n"
+        f"• /next_matches_league <league_id>: Partidos del día de los próximos partidos del torneo seleccionado.\n"
+        f"• /last_match_league <league_id>: último partido jugado del torneo seleccionado.\n"
+        f"• /available_leagues: torneos disponibles para consultar con sus respectivos ids.\n"
+        f"• /today_matches [opt]<league_id>: partidos de hoy (de los equipos disponibles).\n"
+        f"• /tomorrow_matches [opt]<league_id>: partidos de mañana (de los equipos disponibles).\n"
+        f"• /last_played_matches [opt]<league_id>: partidos jugados el día de ayer (de los equipos disponibles)."
     )
     await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
 
@@ -71,26 +61,45 @@ async def available_leagues(update: Update, context):
         f" {Emojis.TELEVISION.value} Estos son los torneos disponibles:\n\n"
         f"{notifier_commands_handler.available_leagues_text()}"
     )
-    await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+    await context.bot.send_message(chat_id=update.effective_chat.id, text=text, parse_mode="HTML")
 
 
 async def search_team(update: Update, context):
     logger.info(
         f"'search_team {' '.join(context.args)}' command executed - by {update.effective_user.name}"
     )
-    command_handler = SearchTeamCommandHandler(
+    command_handler = SearchTeamLeagueCommandHandler(
         context.args, update.effective_user.first_name
     )
     validated_input = command_handler.validate_command_input()
 
     if validated_input:
         await context.bot.send_message(
-            chat_id=update.effective_chat.id, text=validated_input
+            chat_id=update.effective_chat.id, text=validated_input, parse_mode="HTML"
         )
     else:
-        text = command_handler.next_match_team_notif()
+        text = command_handler.search_team_notif()
         logger.info(f"Search Team - text: {text}")
-        context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=text, parse_mode="HTML")
+
+
+async def search_league(update: Update, context):
+    logger.info(
+        f"'search_league {' '.join(context.args)}' command executed - by {update.effective_user.name}"
+    )
+    command_handler = SearchTeamLeagueCommandHandler(
+        context.args, update.effective_user.first_name
+    )
+    validated_input = command_handler.validate_command_input()
+
+    if validated_input:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id, text=validated_input, parse_mode="HTML"
+        )
+    else:
+        text = command_handler.search_league_notif()
+        logger.info(f"Search League - text: {text}")
+        await context.bot.send_message(chat_id=update.effective_chat.id, text=text, parse_mode="HTML")
 
 
 async def next_match(update: Update, context):
@@ -172,7 +181,7 @@ async def next_match_league(update: Update, context):
                 parse_mode="HTML",
             )
         else:
-            context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+            await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
 
 
 async def next_matches_league(update: Update, context):
@@ -221,7 +230,7 @@ async def last_match_league(update: Update, context):
                 parse_mode="HTML",
             )
         else:
-            context.bot.send_message(chat_id=update.effective_chat.id, text=text)
+            await context.bot.send_message(chat_id=update.effective_chat.id, text=text)
 
 
 async def today_matches(update: Update, context):
@@ -300,6 +309,7 @@ if __name__ == "__main__":
     application = ApplicationBuilder().token(NotifConfig.TELEGRAM_TOKEN).build()
     start_handler = CommandHandler("start", start)
     search_team_handler = CommandHandler("search_team", search_team)
+    search_league_handler = CommandHandler("search_league", search_league)
     next_match_handler = CommandHandler("next_match", next_match)
     last_match_handler = CommandHandler("last_match", last_match)
     next_match_league_handler = CommandHandler("next_match_league", next_match_league)
@@ -312,7 +322,6 @@ if __name__ == "__main__":
     last_played_matches_handler = CommandHandler(
         "last_played_matches", last_played_matches
     )
-    available_teams_handler = CommandHandler("available_teams", available_teams)
     available_leagues_handler = CommandHandler("available_leagues", available_leagues)
     help_handler = CommandHandler("help", help)
 
@@ -325,9 +334,9 @@ if __name__ == "__main__":
     application.add_handler(help_handler)
     application.add_handler(today_matches_handler)
     application.add_handler(last_played_matches_handler)
-    application.add_handler(available_teams_handler)
     application.add_handler(tomorrow_matches_handler)
     application.add_handler(available_leagues_handler)
     application.add_handler(search_team_handler)
+    application.add_handler(search_league_handler)
 
     application.run_polling()

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -30,9 +30,18 @@ class FixturesDBManager:
         team_statement = select(DBTeam).where(DBTeam.id == team_id)
         return self._notifier_db_manager.select_records(team_statement)
 
+    def get_all_leagues(self) -> Optional[List[DBLeague]]:
+        return self._notifier_db_manager.select_records(select(DBLeague).order_by(DBLeague.id))
+
     def get_league(self, league_id: int) -> Optional[DBLeague]:
         league_statement = select(DBLeague).where(DBLeague.id == league_id)
         return self._notifier_db_manager.select_records(league_statement)
+
+    def get_leagues_by_name(self, name: str) -> Optional[DBTeam]:
+        teams_statement = select(DBLeague).where(
+            func.lower(DBLeague.name).ilike(f"%{name.lower()}%")
+        )
+        return self._notifier_db_manager.select_records(teams_statement)
 
     def get_teams_by_name(self, name: str) -> Optional[DBTeam]:
         teams_statement = select(DBTeam).where(

--- a/src/db/fixtures_db_manager.py
+++ b/src/db/fixtures_db_manager.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 from sqlalchemy import asc, desc
-from sqlmodel import select, or_
+from sqlmodel import select, or_, func
 
 from src.db.db_manager import NotifierDBManager
 from src.db.notif_sql_models import (
@@ -33,6 +33,12 @@ class FixturesDBManager:
     def get_league(self, league_id: int) -> Optional[DBLeague]:
         league_statement = select(DBLeague).where(DBLeague.id == league_id)
         return self._notifier_db_manager.select_records(league_statement)
+
+    def get_teams_by_name(self, name: str) -> Optional[DBTeam]:
+        teams_statement = select(DBTeam).where(
+            func.lower(DBTeam.name).ilike(f"%{name.lower()}%")
+        )
+        return self._notifier_db_manager.select_records(teams_statement)
 
     def get_games_in_surrounding_n_days(
         self, days: int, league: str = ""
@@ -69,20 +75,28 @@ class FixturesDBManager:
         return surrounding_fixtures
 
     def get_fixtures_by_team(self, team_id: int) -> Optional[List[DBFixture]]:
-        fixtures_statement = select(DBFixture).where(
-            or_(
-                DBFixture.home_team == team_id,
-                DBFixture.away_team == team_id,
+        fixtures_statement = (
+            select(DBFixture)
+            .where(
+                or_(
+                    DBFixture.home_team == team_id,
+                    DBFixture.away_team == team_id,
+                )
             )
-        ).order_by(asc(DBFixture.bsas_date))
+            .order_by(asc(DBFixture.bsas_date))
+        )
 
         return self._notifier_db_manager.select_records(fixtures_statement)
 
-    def get_fixtures_by_league(self, league_id: int, date: str = "") -> Optional[List[DBFixture]]:
+    def get_fixtures_by_league(
+        self, league_id: int, date: str = ""
+    ) -> Optional[List[DBFixture]]:
         fixtures_statement = select(DBFixture).where(DBFixture.league == league_id)
 
         if date:
-            fixtures_statement = fixtures_statement.where(DBFixture.bsas_date.contains(date))
+            fixtures_statement = fixtures_statement.where(
+                DBFixture.bsas_date.contains(date)
+            )
 
         fixtures_statement = fixtures_statement.order_by(asc(DBFixture.bsas_date))
 


### PR DESCRIPTION
Adding functionality for managing commands by `ids` of existing entities (`teams` and `leagues`) in the database. 
Therefore commands are no executed anymore by names of `manages_teams` or `managed_leagues` but by `ids` of any of the teams in the database.

 - Introduced commands: `/search_team` and `/search_league`
 - Removed command `/available_teams`
 - `available_leagues` commands now returns ALL the tournaments that exist on the database